### PR TITLE
feat: Add LightWeight GraphQL Client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ DerivedData/
 .swiftpm/configuration/registries.json
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
+**/Package.resolved

--- a/Package.swift
+++ b/Package.swift
@@ -23,6 +23,13 @@ let package = Package(
                 .product(name: "ResourceExtension", package: "opentelemetry-swift"),
             ]
         ),
+        .testTarget(
+            name: "CommonTests",
+            dependencies: [
+                "Common"
+            ],
+            resources: [.process("GraphQL/Queries")]
+        ),
         .target(name: "CrashReporter"),
         .target(
             name: "CrashReporterLive",

--- a/Sources/Common/AtomicDictionary.swift
+++ b/Sources/Common/AtomicDictionary.swift
@@ -20,6 +20,6 @@ where Key: Hashable, Key: Sendable {
   }
 
   public var debugDescription: String {
-    return storage.debugDescription
+      return queue.sync { storage.debugDescription }
   }
 }

--- a/Sources/Common/GraphQL/GraphQLClient.swift
+++ b/Sources/Common/GraphQL/GraphQLClient.swift
@@ -1,0 +1,162 @@
+import Foundation
+
+public final class GraphQLClient {
+    private let endpoint: URL
+    private let network: NetworkClient
+    private let decoder: JSONDecoder
+    private let defaultHeaders: [String: String]
+
+    public init(endpoint: URL,
+                network: NetworkClient = URLSessionNetworkClient(),
+                decoder: JSONDecoder = JSONDecoder(),
+                defaultHeaders: [String: String] = [
+                    "Content-Type": "application/json",
+                    "Accept": "application/json"
+                ]) {
+        self.endpoint = endpoint
+        self.network = network
+        self.decoder = decoder
+        self.defaultHeaders = defaultHeaders
+    }
+
+    /// Execute a GraphQL operation from stirng query
+    /// - Parameters:
+    ///   - query: Query in graphql format
+    ///   - variables: Codable variables (optional)
+    ///   - operationName: Operation name (optional)
+    ///   - headers: Extra headers (merged over defaultHeaders)
+    public func execute<Variables: Encodable, Output: Decodable>(
+        query: String,
+        variables: Variables? = nil,
+        operationName: String? = nil,
+        headers: [String: String] = [:]
+    ) async throws -> Output {
+        let gqlRequest = GraphQLRequest(query: query, variables: variables, operationName: operationName)
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.httpBody = try gqlRequest.httpBody()
+
+        let combinedHeaders = defaultHeaders.merging(headers) { _, new in new }
+        combinedHeaders.forEach { request.setValue($0.value, forHTTPHeaderField: $0.key) }
+
+        let data = try await network.send(request)
+
+        do {
+            let envelope = try decoder.decode(GraphQLResponse<Output>.self, from: data)
+            if let errors = envelope.errors, !errors.isEmpty {
+                throw GraphQLClientError.graphQLErrors(errors)
+            }
+            guard let value = envelope.data else {
+                throw GraphQLClientError.missingData
+            }
+            return value
+        } catch {
+            throw GraphQLClientError.decoding(error)
+        }
+    }
+    
+    /// Execute a GraphQL operation where the query is loaded from a .graphql file in a bundle.
+    /// - Parameters:
+    ///   - resource: Filename without extension (e.g., "GetUser")
+    ///   - ext: File extension (defaults to "graphql")
+    ///   - bundle: Bundle to search (defaults to .main)
+    ///   - variables: Codable variables (optional)
+    ///   - operationName: Operation name (optional)
+    ///   - headers: Extra headers (merged over defaultHeaders)
+    public func executeFromFile<Variables: Encodable, Output: Decodable>(
+        resource: String,
+        ext: String = "graphql",
+        bundle: Bundle = Bundle.main,
+        variables: Variables? = nil,
+        operationName: String? = nil,
+        headers: [String: String] = [:]
+    ) async throws -> Output {
+        guard let url = bundle.url(forResource: resource, withExtension: ext) else {
+            throw GraphQLClientError.queryFileNotFound("\(resource).\(ext)")
+        }
+
+        let query: String
+        do {
+            query = try String(contentsOf: url, encoding: .utf8)
+        } catch {
+            throw GraphQLClientError.unreadableQueryFile(url, error)
+        }
+
+        return try await execute(
+            query: query,
+            variables: variables,
+            operationName: operationName,
+            headers: headers
+        )
+    }
+}
+
+/// Standard GraphQL envelope: { data, errors }
+private struct GraphQLResponse<DataType: Decodable>: Decodable {
+    let data: DataType?
+    let errors: [GraphQLError]?
+}
+
+public enum GraphQLClientError: Error, CustomStringConvertible {
+    case graphQLErrors([GraphQLError])
+    case missingData
+    case decoding(Error)
+    case queryFileNotFound(String)
+    case unreadableQueryFile(URL, Error?)
+
+    public var description: String {
+        switch self {
+        case .graphQLErrors(let errors):
+            return "GraphQL errors: \(errors.map(\.message).joined(separator: " | "))"
+        case .missingData:
+            return "Missing `data` in GraphQL response"
+        case .decoding(let error):
+            return "Decoding error: \(error)"
+        case .queryFileNotFound(let name):
+            return "GraphQL file '\(name)' not found in bundle"
+        case .unreadableQueryFile(let url, let err):
+            return "Could not read GraphQL file at \(url). \(err?.localizedDescription ?? "")"
+        }
+    }
+}
+
+public struct GraphQLError: Decodable {
+    public let message: String
+}
+
+public struct GraphQLEmptyData: Decodable {}
+
+extension GraphQLClient {
+    public func executeIgnoringData<Variables: Encodable>(
+        query: String,
+        variables: Variables? = nil,
+        operationName: String? = nil,
+        headers: [String: String] = [:]
+    ) async throws {
+        // Reuse EmptyData so decoding still works with `{ "data": null }` or `{ "data": {} }`
+        _ = try await execute(
+            query: query,
+            variables: variables,
+            operationName: operationName,
+            headers: headers
+        ) as GraphQLEmptyData
+    }
+
+    public func executeFromFileIgnoringData<Variables: Encodable>(
+        resource: String,
+        ext: String = "graphql",
+        bundle: Bundle = .main,
+        variables: Variables? = nil,
+        operationName: String? = nil,
+        headers: [String: String] = [:]
+    ) async throws {
+        _ = try await executeFromFile(
+            resource: resource,
+            ext: ext,
+            bundle: bundle,
+            variables: variables,
+            operationName: operationName,
+            headers: headers
+        ) as GraphQLEmptyData
+    }
+}

--- a/Sources/Common/GraphQL/GraphQLRequest.swift
+++ b/Sources/Common/GraphQL/GraphQLRequest.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Encodes the GraphQL POST body: { query, variables, operationName }
+public struct GraphQLRequest<Variables: Encodable>: Encodable {
+    public let query: String
+    public let variables: Variables?
+    public let operationName: String?
+
+    public init(query: String,
+                variables: Variables? = nil,
+                operationName: String? = nil) {
+        self.query = query
+        self.variables = variables
+        self.operationName = operationName
+    }
+
+    /// Create the HTTP body data for this request.
+    /// You can reuse this anywhere you need to build a GraphQL body.
+    public func httpBody(encoder: JSONEncoder = JSONEncoder()) throws -> Data {
+        try encoder.encode(self)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case query
+        case variables
+        case operationName
+    }
+}

--- a/Sources/Common/Network/NetworkClient.swift
+++ b/Sources/Common/Network/NetworkClient.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+public enum NetworkError: Error, CustomStringConvertible {
+    case invalidResponse
+    case httpStatus(Int, data: Data?)
+    case transport(Error)
+
+    public var description: String {
+        switch self {
+        case .invalidResponse: return "Invalid response type"
+        case .httpStatus(let code, _): return "HTTP status \(code)"
+        case .transport(let error): return "Transport error: \(error)"
+        }
+    }
+}
+
+public protocol NetworkClient {
+    func send(_ request: URLRequest) async throws -> Data
+}
+
+public final class URLSessionNetworkClient: NetworkClient {
+    private let session: URLSession
+
+    public init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    public func send(_ request: URLRequest) async throws -> Data {
+        do {
+            let (data, response) = try await session.data(for: request)
+            guard let http = response as? HTTPURLResponse else {
+                throw NetworkError.invalidResponse
+            }
+            guard (200...299).contains(http.statusCode) else {
+                throw NetworkError.httpStatus(http.statusCode, data: data)
+            }
+            return data
+        } catch {
+            throw NetworkError.transport(error)
+        }
+    }
+}

--- a/Tests/CommonTests/GraphQL/GraphQLClientTests.swift
+++ b/Tests/CommonTests/GraphQL/GraphQLClientTests.swift
@@ -1,0 +1,211 @@
+import Foundation
+import Testing
+@testable import Common
+
+// MARK: - Test helpers
+
+private struct GetUserOut: Codable, Equatable {
+    struct User: Codable, Equatable {
+        let id: String
+        let name: String
+    }
+    let user: User
+}
+
+private struct Vars: Encodable { let id: String }
+
+private final class MockNetworkClient: NetworkClient {
+    enum Mode {
+        case succeed(Data),
+             fail(Error)
+    }
+    var mode: Mode
+    var lastRequest: URLRequest?
+    
+    init(mode: Mode) { self.mode = mode }
+    
+    func send(_ request: URLRequest) async throws -> Data {
+        lastRequest = request
+        switch mode {
+        case .succeed(let data): return data
+        case .fail(let error): throw error
+        }
+    }
+}
+
+private struct En: Encodable { let message: String }
+private struct Env<T: Encodable>: Encodable { let data: T?; let errors: [En]? }
+
+private func makeEnvelope<DataType: Encodable>(
+    data: DataType?,
+    errors: [String]? = nil
+) throws -> Data {
+    let env = Env(data: data, errors: errors?.map(En.init(message:)))
+    return try JSONEncoder().encode(env)
+}
+
+@Suite("GraphQLClient")
+struct GraphQLClientTests {
+    
+    @Test("Decodes success data and merges headers")
+    func successDecodesData() async throws {
+        // GIVEN
+        let expected = GetUserOut(user: .init(id: "1", name: "Ada"))
+        let payload = try makeEnvelope(data: expected)
+        let mock = MockNetworkClient(mode: .succeed(payload))
+        
+        let client = GraphQLClient(
+            endpoint: URL(string: "https://example.com/graphql")!,
+            network: mock,
+            decoder: JSONDecoder(),
+            defaultHeaders: [
+                "Authorization": "Bearer token",
+                "Content-Type": "application/json", // default anyway
+                "Accept": "application/json"
+            ]
+        )
+        
+        // WHEN
+        let query = "query GetUser($id: ID!) { user(id: $id) { id name } }"
+        let out: GetUserOut = try await client.execute(
+            query: query,
+            variables: Vars(id: "1"),
+            operationName: "GetUser",
+            headers: ["X-Trace-Id": "trace-1"]
+        )
+        
+        // THEN
+        #expect(out == expected)
+        
+        let req = try #require(mock.lastRequest)
+        #expect(req.httpMethod == "POST")
+        #expect(req.value(forHTTPHeaderField: "Authorization") == "Bearer token")
+        #expect(req.value(forHTTPHeaderField: "X-Trace-Id") == "trace-1")
+        #expect(req.value(forHTTPHeaderField: "Content-Type") == "application/json")
+        #expect(req.value(forHTTPHeaderField: "Accept") == "application/json")
+        #expect(req.httpBody != nil)
+    }
+    
+    @Test("Surfaces GraphQL errors")
+    func graphQLErrorsAreSurfaced() async {
+        let payload = try! makeEnvelope(data: Optional<GetUserOut>.none, errors: ["Oh no", "Bad var"])
+        let mock = MockNetworkClient(mode: .succeed(payload))
+        let client = GraphQLClient(endpoint: URL(string: "https://example.com/graphql")!, network: mock)
+        
+        await #expect(throws: GraphQLClientError.self) {
+            let _: GetUserOut = try await client.execute(
+                query: "query { _ }",
+                variables: Vars(id: "x")
+            )
+        }
+    }
+    
+    @Test("Throws on missing data (no errors)")
+    func missingDataThrows() async {
+        let payload = try! makeEnvelope(data: Optional<GetUserOut>.none, errors: nil)
+        let mock = MockNetworkClient(mode: .succeed(payload))
+        let client = GraphQLClient(endpoint: URL(string: "https://example.com/graphql")!, network: mock)
+        
+        await #expect(throws: GraphQLClientError.self) {
+            let _: GetUserOut = try await client.execute(query: "query { _ }", variables: Vars(id: "x"))
+        }
+    }
+    
+    @Test("Throws on decoding error")
+    func decodingErrorThrows() async {
+        struct Wrong: Encodable { let wrong: String }
+        let payload = try! makeEnvelope(data: Wrong(wrong: "nope"))
+        let mock = MockNetworkClient(mode: .succeed(payload))
+        let client = GraphQLClient(endpoint: URL(string: "https://example.com/graphql")!, network: mock)
+        
+        await #expect(throws: GraphQLClientError.self) {
+            let _: GetUserOut = try await client.execute(query: "query { _ }", variables: Vars(id: "x"))
+        }
+    }
+    
+    @Test("Network errors propagate from NetworkClient")
+    func networkErrorPropagates() async {
+        let mock = MockNetworkClient(mode: .fail(NetworkError.httpStatus(401, data: Data("nope".utf8))))
+        let client = GraphQLClient(endpoint: URL(string: "https://example.com/graphql")!, network: mock)
+        
+        await #expect(throws: NetworkError.self) {
+            let _: GetUserOut = try await client.execute(query: "query { _ }", variables: Vars(id: "x"))
+        }
+    }
+    
+    @Test("Per-request headers override defaults")
+    func perRequestHeadersOverrideDefaults() async throws {
+        let expected = GetUserOut(user: .init(id: "1", name: "Ada"))
+        let payload = try makeEnvelope(data: expected)
+        let mock = MockNetworkClient(mode: .succeed(payload))
+        let client = GraphQLClient(
+            endpoint: URL(string: "https://example.com/graphql")!,
+            network: mock,
+            defaultHeaders: [
+                "Authorization": "Bearer OLD",
+                "Accept": "application/json"
+            ]
+        )
+        
+        let _: GraphQLEmptyData = try await client.execute(
+            query: "query { _ }",
+            variables: Vars(id: "1"),
+            headers: ["Authorization": "Bearer NEW"]
+        )
+        
+        let req = try #require(mock.lastRequest)
+        #expect(req.value(forHTTPHeaderField: "Authorization") == "Bearer NEW")
+        #expect(req.value(forHTTPHeaderField: "Accept") == "application/json")
+    }
+    
+    @Test("executeIgnoringData convenience")
+    func executeIgnoringData() async throws {
+        struct Trivial: Encodable {}
+        let payload = try makeEnvelope(data: Trivial())
+        let mock = MockNetworkClient(mode: .succeed(payload))
+        let client = GraphQLClient(endpoint: URL(string: "https://example.com/graphql")!, network: mock)
+        
+        try await client.executeIgnoringData(
+            query: "mutation { logout }",
+            variables: ["reason": "user"]
+        )
+        
+        #expect(mock.lastRequest?.httpBody != nil)
+    }
+    
+    @Test("executeFromFile loads .graphql from bundle")
+    func executeFromFileLoadsAndRuns() async throws {
+        // Put GetUser.graphql in your TEST target resources:
+        // 
+        let expected = GetUserOut(user: .init(id: "42", name: "Linus"))
+        let payload = try makeEnvelope(data: expected)
+        let mock = MockNetworkClient(mode: .succeed(payload))
+        let client = GraphQLClient(endpoint: URL(string: "https://example.com/graphql")!, network: mock)
+        
+        let bundle = Bundle(for: DummyClass.self)
+        let out: GetUserOut = try await client.executeFromFile(
+            resource: "getUser",
+            bundle: Bundle.module,
+            variables: Vars(id: "42"),
+            operationName: "GetUser"
+        )
+        
+        #expect(out == expected)
+    }
+    
+    @Test("executeFromFile throws when file missing")
+    func executeFromFileNotFoundThrows() async {
+        let mock = MockNetworkClient(mode: .succeed(Data()))
+        let client = GraphQLClient(endpoint: URL(string: "https://example.com/graphql")!, network: mock)
+        let bundle = Bundle(for: DummyClass.self)
+
+        await #expect(throws: GraphQLClientError.self) {
+            let _: GetUserOut = try await client.executeFromFile(resource: "NoSuch",
+                                                                 bundle: bundle,
+                                                                 variables: Vars(id: "42"))
+        }
+    }
+}
+
+// Helper for non-SPM bundle lookup
+private final class DummyClass {}

--- a/Tests/CommonTests/GraphQL/GraphQLRequestTests.swift
+++ b/Tests/CommonTests/GraphQL/GraphQLRequestTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Testing
+@testable import Common
+
+@Suite("GraphQLRequest")
+struct GraphQLRequestTests {
+    private struct Vars: Encodable {
+        let id: String;
+        let limit: Int
+    }
+    
+    @Test("Encodes query + variables + operationName")
+    func encodesQueryVariablesAndOperationName() throws {
+        
+        let req = GraphQLRequest(
+            query: "query Q($id: ID!, $limit: Int!) { user(id: $id) { id } }",
+            variables: Vars(id: "123", limit: 10),
+            operationName: "Q"
+        )
+        
+        let data = try req.httpBody()
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        
+        #expect(json?["query"] as? String == "query Q($id: ID!, $limit: Int!) { user(id: $id) { id } }")
+        #expect(json?["operationName"] as? String == "Q")
+        
+        let vars = json?["variables"] as? [String: Any]
+        #expect(vars?["id"] as? String == "123")
+        #expect(vars?["limit"] as? Int == 10)
+    }
+    
+    @Test("Encodes [String: AnyEncodable] variables")
+    func encodesAnyEncodableDictionaryVariables() throws {
+        let variables: [String: String] = [
+            "id": "abc",
+            "count": "5",
+            "flags": "a",
+            "meta": "k"
+        ]
+        
+        let req = GraphQLRequest(query: "query Q { _ }", variables: variables)
+        let data = try req.httpBody()
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let vars = json?["variables"] as? [String: Any]
+        
+        #expect(vars?["id"] as? String == "abc")
+        #expect(vars?["count"] as? String == "5")
+    }
+}

--- a/Tests/CommonTests/GraphQL/Queries/getUser.graphql
+++ b/Tests/CommonTests/GraphQL/Queries/getUser.graphql
@@ -1,0 +1,6 @@
+query getUser(
+    $id: ID!
+) {
+    user(id: $id)
+    { id name }
+}


### PR DESCRIPTION
feat: Add LightWeight GraphQL Client

- It uses query strings and filename to specify query.
- Encodable structures to pass variables