### PR TITLE
fix: requirement 1.2.3.6 span name in eval hook

### DIFF
--- a/Sources/LaunchDarklyObservability/Plugin/EvalTracingHook.swift
+++ b/Sources/LaunchDarklyObservability/Plugin/EvalTracingHook.swift
@@ -34,7 +34,7 @@ public final class EvalTracingHook: @unchecked Sendable, Hook {
         /// https://github.com/launchdarkly/sdk-specs/tree/main/specs/OTEL-openteletry-integration#requirement-1236
         lazy var span: any Span = {
             let span = tracer
-                .spanBuilder(spanName: String(format: "LDClient.%@", seriesContext.methodName))
+                .spanBuilder(spanName: "LDClient.\(seriesContext.methodName)")
                 .setStartTime(time: Date())
                 .startSpan()
  

--- a/Sources/LaunchDarklyObservability/Plugin/EvalTracingHook.swift
+++ b/Sources/LaunchDarklyObservability/Plugin/EvalTracingHook.swift
@@ -30,9 +30,11 @@ public final class EvalTracingHook: @unchecked Sendable, Hook {
             instrumentationVersion: version
         )
         
+        /// Requirement 1.2.3.6
+        /// https://github.com/launchdarkly/sdk-specs/tree/main/specs/OTEL-openteletry-integration#requirement-1236
         lazy var span: any Span = {
             let span = tracer
-                .spanBuilder(spanName: Self.FEATURE_FLAG_SPAN_NAME)
+                .spanBuilder(spanName: String(format: "LDClient.%@", seriesContext.methodName))
                 .setStartTime(time: Date())
                 .startSpan()
  


### PR DESCRIPTION
Based on Requirement 1.2.3.6 from otel integration doc https://github.com/launchdarkly/sdk-specs/tree/main/specs/OTEL-openteletry-integration#requirement-1236
