### PR TITLE
fix: get sampling config

### DIFF
--- a/Sources/Observability/SamplingConfigClient.swift
+++ b/Sources/Observability/SamplingConfigClient.swift
@@ -14,10 +14,12 @@ final class DefaultSamplingConfigClient: SamplingConfigClient {
     }
     
     func getSamplingConfig(sdkKey: String) async throws -> SamplingConfig? {
-        try await client.executeFromFile(
+        let data: SamplingData = try await client.executeFromFile(
             resource: "GetSamplingConfigQuery",
             bundle: .module,
             variables: OrganizationVerboseIdVar(organization_verbose_id: sdkKey)
         )
+        
+        return data.sampling
     }
 }

--- a/Sources/Sampling/SamplingConfig.swift
+++ b/Sources/Sampling/SamplingConfig.swift
@@ -114,9 +114,6 @@ public struct SamplingConfig: Codable {
     }
 }
 
-public struct Root: Codable {
-    public struct SamplingData: Codable {
-        public let sampling: SamplingConfig
-    }
-    public let data: SamplingData
+public struct SamplingData: Codable {
+    public let sampling: SamplingConfig
 }


### PR DESCRIPTION
fix getting empty sampling config even though config contains sampling criterias