### PR TITLE
feat: network request context propagation

### DIFF
--- a/ExampleApp/ExampleApp/AppDelegate.swift
+++ b/ExampleApp/ExampleApp/AppDelegate.swift
@@ -12,6 +12,11 @@ let config = { () -> LDConfig in
         Observability(
             options: .init(
                 otlpEndpoint: "http://localhost:4318",
+                tracingOrigins: .all,
+                urlBlocklist: [
+                    "backend.myapp.com",
+//                    "jsonplaceholder.typicode.com"
+                ],
                 sessionBackgroundTimeout: 3,
                 isDebug: true,
                 disableLogs: false,

--- a/ExampleApp/ExampleApp/AppDelegate.swift
+++ b/ExampleApp/ExampleApp/AppDelegate.swift
@@ -11,7 +11,7 @@ let config = { () -> LDConfig in
     config.plugins = [
         Observability(
             options: .init(
-//                otlpEndpoint: "http://localhost:4318",
+                otlpEndpoint: "http://localhost:4318",
                 sessionBackgroundTimeout: 3,
                 isDebug: true,
                 disableLogs: false,

--- a/ExampleApp/ExampleApp/Instrumentation/Automatic/NetworkRequestView.swift
+++ b/ExampleApp/ExampleApp/Instrumentation/Automatic/NetworkRequestView.swift
@@ -20,5 +20,13 @@ struct NetworkRequestView: View {
                 
             }
         }
+        .task {
+            guard let url = URL(string: "http://localhost/something") else { return }
+            do {
+                let (_, _) = try await URLSession.shared.data(from: url)
+            } catch {
+                
+            }
+        }
     }
 }

--- a/Sources/API/Options.swift
+++ b/Sources/API/Options.swift
@@ -11,6 +11,7 @@ import ResourceExtension
 ///   - backendUrl The backend URL for non-OTLP operations. Defaults to LaunchDarkly url.
 ///   - resourceAttributes Additional resource attributes to include in telemetry data.
 ///   - customHeaders Custom headers to include with OTLP exports.
+///   - tracingOrigins Specifies where the backend of the app lives. If specified, the SDK will attach tracing headers to outgoing requests whose destination URLs match a substring or regexp from this list, so that backend errors can be linked back to the session.
 ///   - sessionBackgroundTimeout Session timeout if app is backgrounded. Defaults to 15 minutes. 15 * 60
 ///   - isDebug Enables verbose telemetry logging if true as well as other debug functionality. Defaults to false.
 ///   - disableErrorTracking Disables error tracking if true. Defaults to false.
@@ -22,12 +23,20 @@ import ResourceExtension
 ///
 
 public struct Options {
+    public enum TracingOrigin {
+        case all
+        case traceOrigin
+        case list([String])
+        case regex([String])
+    }
     public let serviceName: String
     public let serviceVersion: String
     public let otlpEndpoint: String
     public let backendUrl: String
     public private(set) var resourceAttributes: [String: AttributeValue]
     public let customHeaders: [(String, String)]
+    public let tracingOrigins: TracingOrigin
+    public let urlBlocklist: [String]
     public let sessionBackgroundTimeout: TimeInterval
     public let isDebug: Bool
     public let disableErrorTracking: Bool
@@ -43,6 +52,8 @@ public struct Options {
         backendUrl: String = "https://pub.observability.app.launchdarkly.com",
         resourceAttributes: [String: AttributeValue] = [:],
         customHeaders: [(String, String)] = [],
+        tracingOrigins: TracingOrigin = .all,
+        urlBlocklist: [String] = [],
         sessionBackgroundTimeout: TimeInterval = 15 * 60,
         isDebug: Bool = false,
         disableErrorTracking: Bool = false,
@@ -57,6 +68,8 @@ public struct Options {
         self.backendUrl = backendUrl
         self.resourceAttributes = resourceAttributes.merging(Self.defaultResource.attributes) { (current, _) in current }
         self.customHeaders = customHeaders
+        self.tracingOrigins = tracingOrigins
+        self.urlBlocklist = urlBlocklist
         self.sessionBackgroundTimeout = sessionBackgroundTimeout
         self.isDebug = isDebug
         self.disableErrorTracking = disableErrorTracking

--- a/Sources/LaunchDarklyObservability/Plugin/Observability.swift
+++ b/Sources/LaunchDarklyObservability/Plugin/Observability.swift
@@ -34,6 +34,8 @@ public final class Observability: Plugin {
             backendUrl: options.backendUrl,
             resourceAttributes: options.resourceAttributes.merging(resourceAttributes) { (old, _) in old },
             customHeaders: options.customHeaders,
+            tracingOrigins: options.tracingOrigins,
+            urlBlocklist: options.urlBlocklist,
             sessionBackgroundTimeout: options.sessionBackgroundTimeout,
             isDebug: options.isDebug,
             disableErrorTracking: options.disableErrorTracking,

--- a/Sources/Observability/InstrumentationManager.swift
+++ b/Sources/Observability/InstrumentationManager.swift
@@ -254,18 +254,11 @@ final class InstrumentationManager {
         }
     }
     
-    private func registerPropagators() {
-        OpenTelemetry.registerPropagators(
-            textPropagators: [W3CTraceContextPropagator()],
-            baggagePropagator: W3CBaggagePropagator()
-        )
-    }
-    
     private func initializeInstrumentation(options: Options) {
         initializeTracer(withSampler: sampler, options: options)
         initializeLogger(withSampler: sampler, options: options)
         initializeMeter(options: options)
-        registerPropagators()
+        
         self.urlSessionInstrumentation = URLSessionInstrumentation(
             configuration: URLSessionInstrumentationConfiguration(
                 shouldInstrument: { urlRequest in

--- a/Sources/Observability/InstrumentationManager.swift
+++ b/Sources/Observability/InstrumentationManager.swift
@@ -307,7 +307,7 @@ final class InstrumentationManager {
                     case .all:
                         return true
                     case .traceOrigin:
-                        let patterns = [#"/localhost|^\/"#]
+                        let patterns = ["localhost", "^/"]
                         
                         return patterns.contains { regex in
                             url.absoluteString.lowercased().matches(regex)

--- a/Sources/Observability/InstrumentationManager.swift
+++ b/Sources/Observability/InstrumentationManager.swift
@@ -250,10 +250,18 @@ final class InstrumentationManager {
         }
     }
     
+    private func registerPropagators() {
+        OpenTelemetry.registerPropagators(
+            textPropagators: [W3CTraceContextPropagator()],
+            baggagePropagator: W3CBaggagePropagator()
+        )
+    }
+    
     private func initializeInstrumentation(options: Options) {
         initializeTracer(withSampler: sampler, options: options)
         initializeLogger(withSampler: sampler, options: options)
         initializeMeter(options: options)
+        registerPropagators()
         self.urlSessionInstrumentation = URLSessionInstrumentation(
             configuration: URLSessionInstrumentationConfiguration(
                 shouldInstrument: { urlRequest in

--- a/Sources/Observability/InstrumentationManager.swift
+++ b/Sources/Observability/InstrumentationManager.swift
@@ -317,7 +317,7 @@ final class InstrumentationManager {
                             return false
                         }
                         return origins.contains { origin in
-                            origin.contains(url)
+                            url.contains(origin)
                         }
                     case .regex(let regexArray):
                         guard let urlString = urlRequest.url?.absoluteString else {

--- a/Sources/Observability/InstrumentationManager.swift
+++ b/Sources/Observability/InstrumentationManager.swift
@@ -277,7 +277,7 @@ final class InstrumentationManager {
                             return false
                         }
                         return options.urlBlocklist.contains { url in
-                            return requestUrl.lowercased().contains(url)
+                            return requestUrl.lowercased().contains(url.lowercased())
                         }
                     }() == false
                 },
@@ -297,7 +297,7 @@ final class InstrumentationManager {
                         return false
                     }
                     let contains = options.urlBlocklist.contains { blockedUrl in
-                        return url.absoluteString.lowercased().contains(blockedUrl)
+                        return url.absoluteString.lowercased().contains(blockedUrl.lowercased())
                     }
                     guard !contains else {
                         return false
@@ -310,21 +310,21 @@ final class InstrumentationManager {
                         let patterns = [#"/localhost|^\/"#]
                         
                         return patterns.contains { regex in
-                            url.absoluteString.matches(regex)
+                            url.absoluteString.lowercased().matches(regex)
                         }
                     case .list(let origins):
                         guard let url = urlRequest.url?.absoluteString else {
                             return false
                         }
                         return origins.contains { origin in
-                            url.contains(origin)
+                            url.lowercased().contains(origin.lowercased())
                         }
                     case .regex(let regexArray):
                         guard let urlString = urlRequest.url?.absoluteString else {
                             return false
                         }
                         return regexArray.contains { regex in
-                            urlString.matches(regex)
+                            urlString.lowercased().matches(regex)
                         }
                     }
                 },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds configurable tracing header injection with W3C context propagation and URL blocklist, propagating new options through the plugin and updating instrumentation/tracer usage.
> 
> - **Observability API**:
>   - Add `Options.TracingOrigin` enum and new `Options` fields: `tracingOrigins` and `urlBlocklist` (default `.all` / `[]`).
>   - Propagate these options through `Observability` when constructing internal `Options`.
> - **Instrumentation**:
>   - Make `otelTracer` non-optional; update `recordError` and `startSpan` to use non-optional tracer and defer `span.end()`.
>   - Enhance `URLSessionInstrumentation` configuration:
>     - Extend `shouldInstrument` to honor `options.urlBlocklist`.
>     - Add `shouldInjectTracingHeaders` supporting `tracingOrigins` modes: `.all`, `.traceOrigin`, `.list`, `.regex`.
>     - Add `injectCustomHeaders` using W3C text map propagator; introduce `textMapPropagator`, `W3CTraceContextSetter`, and `injectContextInto`.
> - **Example App**:
>   - Configure `Observability.Options` with `otlpEndpoint`, `tracingOrigins: .all`, and `urlBlocklist`.
>   - Add a second network request task to `NetworkRequestView` (`http://localhost/something`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c926f9e630a4febcf1e844bc97b7c1c865a98f41. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->