### PR TITLE
feat: RRWeb events for Keyboard press and RemoteControl press

### DIFF
--- a/Sources/LaunchDarklyObservability/UIInteractions/InputCaptureCoordinator.swift
+++ b/Sources/LaunchDarklyObservability/UIInteractions/InputCaptureCoordinator.swift
@@ -46,6 +46,7 @@ final class InputCaptureCoordinator {
     private let source: UIEventSource
     private let targetResolver: TargetResolving
     private let touchInterpreter: TouchInterpreter
+    private let pressInterpreter: PressInterpreter
     private let receiverChecker: UIEventReceiverChecker
     var onTouch: TouchInteractionYield?
     var onPress: PressInteractionYield?
@@ -54,6 +55,7 @@ final class InputCaptureCoordinator {
          receiverChecker: UIEventReceiverChecker = UIEventReceiverChecker()) {
         self.targetResolver = targetResolver
         self.touchInterpreter = TouchInterpreter()
+        self.pressInterpreter = PressInterpreter()
         self.source = UIWindowSwizzleSource()
         self.receiverChecker = receiverChecker
     }
@@ -93,7 +95,9 @@ final class InputCaptureCoordinator {
                 case .touch(let touchSample):
                     touchInterpreter.process(touchSample: touchSample, yield: onTouch)
                 case .press(let sample):
-                    onPress?(sample)
+                    if let onPress {
+                        pressInterpreter.process(pressInteraction: sample, yield: onPress)
+                    }
                 }
             }
         }
@@ -106,16 +110,14 @@ final class InputCaptureCoordinator {
     ) {
         guard let touches = event.allTouches else { return }
         for touch in touches {
-            guard touch.phase == .began || touch.phase == .ended else { continue }
+            guard touch.phase == .began else { continue }
             let target = targetResolver.resolve(view: touch.view, window: window, event: event)
             let interaction = PressInteraction(
                 phase: PressInteraction.phase(forTouch: touch.phase),
+                kind: .untrackedWindowTouch,
                 timestamp: touch.timestamp,
-                target: target,
-                isKeyboardOriginated: true
+                target: target
             )
-            if case let .other = interaction.kind { continue }
-            
             continuation.yield(.press(interaction))
         }
     }
@@ -146,10 +148,10 @@ final class InputCaptureCoordinator {
     ) {
         guard let pressesEvent = event as? UIPressesEvent else { return }
         for press in pressesEvent.allPresses {
-            guard press.phase == .began || press.phase == .ended else { continue }
+            guard press.phase == .began else { continue }
             let target = targetResolver.resolve(press: press, window: window)
             let interaction = PressInteraction(press: press, target: target)
-            if case let .other = interaction.kind { continue }
+            if case .other = interaction.kind { continue }
             
             continuation.yield(.press(interaction))
         }

--- a/Sources/LaunchDarklyObservability/UIInteractions/InputCaptureCoordinator.swift
+++ b/Sources/LaunchDarklyObservability/UIInteractions/InputCaptureCoordinator.swift
@@ -108,7 +108,12 @@ final class InputCaptureCoordinator {
         for touch in touches {
             guard touch.phase == .began || touch.phase == .ended else { continue }
             let target = targetResolver.resolve(view: touch.view, window: window, event: event)
-            let interaction = PressInteraction(touch: touch, target: target)
+            let interaction = PressInteraction(
+                phase: PressInteraction.phase(forTouch: touch.phase),
+                timestamp: touch.timestamp,
+                target: target,
+                isKeyboardOriginated: true
+            )
             if case let .other = interaction.kind { continue }
             
             continuation.yield(.press(interaction))

--- a/Sources/LaunchDarklyObservability/UIInteractions/InputCaptureCoordinator.swift
+++ b/Sources/LaunchDarklyObservability/UIInteractions/InputCaptureCoordinator.swift
@@ -3,7 +3,7 @@ import UIKit
 
 enum InteractionCaptureItem: Sendable {
     case touch(TouchSample)
-    case press(PressSample)
+    case press(PressInteraction)
 }
 
 struct TouchSample: Sendable {
@@ -40,7 +40,7 @@ struct TouchSample: Sendable {
 }
 
 public typealias TouchInteractionYield = @Sendable (TouchInteraction) -> Void
-public typealias PressSampleYield = @Sendable (PressSample) -> Void
+public typealias PressInteractionYield = @Sendable (PressInteraction) -> Void
 
 final class InputCaptureCoordinator {
     private let source: UIEventSource
@@ -48,7 +48,7 @@ final class InputCaptureCoordinator {
     private let touchInterpreter: TouchInterpreter
     private let receiverChecker: UIEventReceiverChecker
     var onTouch: TouchInteractionYield?
-    var onPress: PressSampleYield?
+    var onPress: PressInteractionYield?
     
     init(targetResolver: TargetResolving = TargetResolver(),
          receiverChecker: UIEventReceiverChecker = UIEventReceiverChecker()) {
@@ -108,10 +108,10 @@ final class InputCaptureCoordinator {
         for touch in touches {
             guard touch.phase == .began || touch.phase == .ended else { continue }
             let target = targetResolver.resolve(view: touch.view, window: window, event: event)
-            let sample = PressSample(touch: touch, target: target)
-            if case let .other = sample.kind { continue }
+            let interaction = PressInteraction(touch: touch, target: target)
+            if case let .other = interaction.kind { continue }
             
-            continuation.yield(.press(sample))
+            continuation.yield(.press(interaction))
         }
     }
     
@@ -143,10 +143,10 @@ final class InputCaptureCoordinator {
         for press in pressesEvent.allPresses {
             guard press.phase == .began || press.phase == .ended else { continue }
             let target = targetResolver.resolve(press: press, window: window)
-            let sample = PressSample(press: press, target: target)
-            if case let .other = sample.kind { continue }
+            let interaction = PressInteraction(press: press, target: target)
+            if case let .other = interaction.kind { continue }
             
-            continuation.yield(.press(sample))
+            continuation.yield(.press(interaction))
         }
     }
 }

--- a/Sources/LaunchDarklyObservability/UIInteractions/PressCaptureModels.swift
+++ b/Sources/LaunchDarklyObservability/UIInteractions/PressCaptureModels.swift
@@ -31,6 +31,7 @@ public struct PressInteraction: Sendable {
         case ended
         case cancelled
         case stationary
+        case unknown
     }
 
     public let phase: Phase
@@ -63,7 +64,10 @@ public struct PressInteraction: Sendable {
         case .ended: return .ended
         case .cancelled: return .cancelled
         case .stationary: return .stationary
-        @unknown default: return .changed
+        case .regionEntered: return .unknown
+        case .regionMoved: return .unknown
+        case .regionExited: return .unknown
+        @unknown default: return .unknown
         }
     }
 
@@ -74,7 +78,7 @@ public struct PressInteraction: Sendable {
         case .ended: return .ended
         case .cancelled: return .cancelled
         case .stationary: return .stationary
-        @unknown default: return .changed
+        @unknown default: return .unknown
         }
     }
 }

--- a/Sources/LaunchDarklyObservability/UIInteractions/PressCaptureModels.swift
+++ b/Sources/LaunchDarklyObservability/UIInteractions/PressCaptureModels.swift
@@ -1,7 +1,7 @@
 #if canImport(UIKit)
 import UIKit
 
-/// Normalized remote / hardware button identity for presses that do not use window coordinates in replay.
+/// Normalized identity for presses that do not use window coordinates in replay.
 public enum RemotePressKind: Sendable, Equatable {
     case upArrow
     case downArrow
@@ -14,10 +14,12 @@ public enum RemotePressKind: Sendable, Equatable {
     case pageDown
     case tvRemoteOneTwoThree
     case tvRemoteFourColors
-    /// Press types introduced after this SDK (see `UIPress.PressType.rawValue`).
-    case other(rawValue: Int)
+    /// Hardware keyboard key press (`UIPress.key != nil`). No key code or text is stored (privacy).
+    case keyboard
     /// `UITouch` on a window skipped by `UIEventReceiverChecker` (e.g. keyboard chrome), recorded without coordinates.
     case untrackedWindowTouch
+    /// Press types introduced after this SDK that are not keyboard-originated (see `UIPress.PressType.rawValue`).
+    case other(rawValue: Int)
 }
 
 /// A `UIPress` that is not mapped through the spatial `TouchSample` → `TouchInteraction` path (e.g. Menu, D-pad, hardware keyboard),
@@ -35,23 +37,23 @@ public struct PressInteraction: Sendable {
     public let kind: RemotePressKind
     public let timestamp: TimeInterval
     public let target: TouchTarget?
-    /// `true` when the press came from a hardware keyboard (`UIPress.key`); does not expose key contents.
-    public let isKeyboardOriginated: Bool
+
+    public var isKeyboard: Bool {
+        kind == .keyboard || kind == .untrackedWindowTouch
+    }
 
     init(press: UIPress, target: TouchTarget?) {
         self.phase = Self.phase(for: press.phase)
-        self.kind = RemotePressKind(pressType: press.type)
+        self.kind = press.key != nil ? .keyboard : RemotePressKind(pressType: press.type)
         self.timestamp = press.timestamp
         self.target = target
-        self.isKeyboardOriginated = press.key != nil
     }
 
-    init(phase: Phase, kind: RemotePressKind = .untrackedWindowTouch, timestamp: TimeInterval, target: TouchTarget?, isKeyboardOriginated: Bool = false) {
+    init(phase: Phase, kind: RemotePressKind = .untrackedWindowTouch, timestamp: TimeInterval, target: TouchTarget?) {
         self.phase = phase
         self.kind = kind
         self.timestamp = timestamp
         self.target = target
-        self.isKeyboardOriginated = isKeyboardOriginated
     }
 
     static func phase(forTouch touchPhase: UITouch.Phase) -> Phase {

--- a/Sources/LaunchDarklyObservability/UIInteractions/PressCaptureModels.swift
+++ b/Sources/LaunchDarklyObservability/UIInteractions/PressCaptureModels.swift
@@ -46,7 +46,7 @@ public struct PressInteraction: Sendable {
         self.isKeyboardOriginated = press.key != nil
     }
 
-    init(phase: Phase, kind: RemotePressKind, timestamp: TimeInterval, target: TouchTarget?, isKeyboardOriginated: Bool) {
+    init(phase: Phase, kind: RemotePressKind = .untrackedWindowTouch, timestamp: TimeInterval, target: TouchTarget?, isKeyboardOriginated: Bool = false) {
         self.phase = phase
         self.kind = kind
         self.timestamp = timestamp
@@ -54,15 +54,7 @@ public struct PressInteraction: Sendable {
         self.isKeyboardOriginated = isKeyboardOriginated
     }
 
-    init(touch: UITouch, target: TouchTarget?) {
-        self.phase = Self.phase(forTouch: touch.phase)
-        self.kind = .untrackedWindowTouch
-        self.timestamp = touch.timestamp
-        self.target = target
-        self.isKeyboardOriginated = false
-    }
-
-    private static func phase(forTouch touchPhase: UITouch.Phase) -> Phase {
+    static func phase(forTouch touchPhase: UITouch.Phase) -> Phase {
         switch touchPhase {
         case .began: return .began
         case .moved: return .changed

--- a/Sources/LaunchDarklyObservability/UIInteractions/PressCaptureModels.swift
+++ b/Sources/LaunchDarklyObservability/UIInteractions/PressCaptureModels.swift
@@ -22,7 +22,7 @@ public enum RemotePressKind: Sendable, Equatable {
 
 /// A `UIPress` that is not mapped through the spatial `TouchSample` → `TouchInteraction` path (e.g. Menu, D-pad, hardware keyboard),
 /// or a touch on a filtered window encoded for replay without pointer coordinates.
-public struct PressSample: Sendable {
+public struct PressInteraction: Sendable {
     public enum Phase: Sendable {
         case began
         case changed
@@ -44,6 +44,14 @@ public struct PressSample: Sendable {
         self.timestamp = press.timestamp
         self.target = target
         self.isKeyboardOriginated = press.key != nil
+    }
+
+    init(phase: Phase, kind: RemotePressKind, timestamp: TimeInterval, target: TouchTarget?, isKeyboardOriginated: Bool) {
+        self.phase = phase
+        self.kind = kind
+        self.timestamp = timestamp
+        self.target = target
+        self.isKeyboardOriginated = isKeyboardOriginated
     }
 
     init(touch: UITouch, target: TouchTarget?) {
@@ -97,6 +105,12 @@ extension RemotePressKind {
             self = .other(rawValue: pressType.rawValue)
         }
     }
+}
+
+/// Touch and press interactions forwarded in order for session replay export.
+public enum InteractionEvent: Sendable {
+    case touch(TouchInteraction)
+    case press(PressInteraction)
 }
 
 #endif

--- a/Sources/LaunchDarklyObservability/UIInteractions/PressInterpreter.swift
+++ b/Sources/LaunchDarklyObservability/UIInteractions/PressInterpreter.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+final class PressInterpreter {
+    func process(pressInteraction: PressInteraction, yield: PressInteractionYield) {
+        let uptimeDifference = Date().timeIntervalSince1970 - ProcessInfo.processInfo.systemUptime
+        let corrected = PressInteraction(
+            phase: pressInteraction.phase,
+            kind: pressInteraction.kind,
+            timestamp: pressInteraction.timestamp + uptimeDifference,
+            target: pressInteraction.target
+        )
+        yield(corrected)
+    }
+}

--- a/Sources/LaunchDarklyObservability/UIInteractions/UserInteractionManager.swift
+++ b/Sources/LaunchDarklyObservability/UIInteractions/UserInteractionManager.swift
@@ -6,18 +6,22 @@ import Combine
 
 public final class UserInteractionManager {
     private var inputCaptureCoordinator: InputCaptureCoordinator
-    private let subject = PassthroughSubject<TouchInteraction, Never>()
+    private let interactionEventSubject = PassthroughSubject<InteractionEvent, Never>()
     
-    public var publisher: AnyPublisher<TouchInteraction, Never> {
-        subject.eraseToAnyPublisher()
+    /// Ordered stream of touches (``TouchInteraction``) and non-spatial ``PressInteraction``.
+    public var interactionEvents: AnyPublisher<InteractionEvent, Never> {
+        interactionEventSubject.eraseToAnyPublisher()
     }
     
     init(options: ObservabilityOptions, yield: @escaping TouchInteractionYield) {
         let targetResolver = TargetResolver()
         self.inputCaptureCoordinator = InputCaptureCoordinator(targetResolver: targetResolver)
-        self.inputCaptureCoordinator.onTouch = { [subject] interaction in
+        self.inputCaptureCoordinator.onTouch = { [interactionEventSubject] interaction in
             yield(interaction)
-            subject.send(interaction)
+            interactionEventSubject.send(.touch(interaction))
+        }
+        self.inputCaptureCoordinator.onPress = { [interactionEventSubject] pressInteraction in
+            interactionEventSubject.send(.press(pressInteraction))
         }
     }
         

--- a/Sources/LaunchDarklySessionReplay/Exporter/PressInteractionPayload.swift
+++ b/Sources/LaunchDarklySessionReplay/Exporter/PressInteractionPayload.swift
@@ -1,9 +1,9 @@
 import Foundation
 import LaunchDarklyObservability
 
-/// Queue item for non-spatial `PressInteraction` values (tvOS remote, filtered-window touches, keyboard-sourced presses).
+/// Queue item for non-spatial `PressInteraction` values (remote control, filtered-window touches, keyboard-sourced presses).
 /// Encoded as RRWeb custom events (`RemoteControl`, `Keyboard`) by `RRWebEventGenerator`.
-struct TVPressInteractionPayload: EventQueueItemPayload {
+struct PressInteractionPayload: EventQueueItemPayload {
     let pressInteraction: PressInteraction
 
     var timestamp: TimeInterval { pressInteraction.timestamp }

--- a/Sources/LaunchDarklySessionReplay/Exporter/RRWebEventGenerator.swift
+++ b/Sources/LaunchDarklySessionReplay/Exporter/RRWebEventGenerator.swift
@@ -187,25 +187,25 @@ actor RRWebEventGenerator {
     
     private func appendPressInteraction(payload: PressInteractionPayload, events: inout [Event]) {
         let press = payload.pressInteraction
-        if press.isKeyboardOriginated {
-            let keyboardPayload = KeyboardPressPayload(phase: press.phase.sessionReplayWirePhase)
-            let eventData = CustomEventData(tag: .keyboardPress, payload: keyboardPayload)
-            events.append(Event(type: .Custom,
-                                 data: AnyEventData(eventData),
-                                 timestamp: press.timestamp,
-                                 _sid: nextSid))
+        let event: Event
+        if press.isKeyboard {
+            let eventData = CustomEventData(tag: .keyboardPress, payload: KeyboardPressPayload())
+            event = Event(type: .Custom,
+                          data: AnyEventData(eventData),
+                          timestamp: press.timestamp,
+                          _sid: nextSid)
         } else {
             let remotePayload = RemoteControlPayload(
-                phase: press.phase.sessionReplayWirePhase,
                 pressType: press.kind.sessionReplayWirePressType,
                 pressTypeSystemRaw: press.kind.sessionReplayUIPressTypeRawIfOther
             )
             let eventData = CustomEventData(tag: .remoteControl, payload: remotePayload)
-            events.append(Event(type: .Custom,
-                                 data: AnyEventData(eventData),
-                                 timestamp: press.timestamp,
-                                 _sid: nextSid))
+            event = Event(type: .Custom,
+                          data: AnyEventData(eventData),
+                          timestamp: press.timestamp,
+                          _sid: nextSid)
         }
+        events.append(event)
     }
     
     func clickEvent(interaction: TouchInteraction) -> Event? {

--- a/Sources/LaunchDarklySessionReplay/Exporter/RRWebEventGenerator.swift
+++ b/Sources/LaunchDarklySessionReplay/Exporter/RRWebEventGenerator.swift
@@ -133,8 +133,8 @@ actor RRWebEventGenerator {
                 events.append(event)
             }
             
-        case let tvPressItem as TVPressInteractionPayload:
-            appendTVPressInteraction(payload: tvPressItem, events: &events)
+        case let pressItem as PressInteractionPayload:
+            appendPressInteraction(payload: pressItem, events: &events)
             
         default:
             break // Item wasn't needed for SessionReplay
@@ -185,25 +185,25 @@ actor RRWebEventGenerator {
         }
     }
     
-    private func appendTVPressInteraction(payload: TVPressInteractionPayload, events: inout [Event]) {
-        let pressInteraction = payload.pressInteraction
-        if pressInteraction.isKeyboardOriginated {
-            let keyboardPayload = KeyboardPressPayload(phase: pressInteraction.phase.sessionReplayWirePhase)
+    private func appendPressInteraction(payload: PressInteractionPayload, events: inout [Event]) {
+        let press = payload.pressInteraction
+        if press.isKeyboardOriginated {
+            let keyboardPayload = KeyboardPressPayload(phase: press.phase.sessionReplayWirePhase)
             let eventData = CustomEventData(tag: .keyboardPress, payload: keyboardPayload)
             events.append(Event(type: .Custom,
                                  data: AnyEventData(eventData),
-                                 timestamp: pressInteraction.timestamp,
+                                 timestamp: press.timestamp,
                                  _sid: nextSid))
         } else {
             let remotePayload = RemoteControlPayload(
-                phase: pressInteraction.phase.sessionReplayWirePhase,
-                pressType: pressInteraction.kind.sessionReplayWirePressType,
-                pressTypeSystemRaw: pressInteraction.kind.sessionReplayUIPressTypeRawIfOther
+                phase: press.phase.sessionReplayWirePhase,
+                pressType: press.kind.sessionReplayWirePressType,
+                pressTypeSystemRaw: press.kind.sessionReplayUIPressTypeRawIfOther
             )
             let eventData = CustomEventData(tag: .remoteControl, payload: remotePayload)
             events.append(Event(type: .Custom,
                                  data: AnyEventData(eventData),
-                                 timestamp: pressInteraction.timestamp,
+                                 timestamp: press.timestamp,
                                  _sid: nextSid))
         }
     }

--- a/Sources/LaunchDarklySessionReplay/Exporter/RRWebEventGenerator.swift
+++ b/Sources/LaunchDarklySessionReplay/Exporter/RRWebEventGenerator.swift
@@ -189,7 +189,10 @@ actor RRWebEventGenerator {
         let press = payload.pressInteraction
         let event: Event
         if press.isKeyboard {
-            let eventData = CustomEventData(tag: .keyboardPress, payload: KeyboardPressPayload())
+            let keyboardPayload = KeyboardPressPayload(
+                target: press.target?.className ?? ""
+            )
+            let eventData = CustomEventData(tag: .keyboardPress, payload: keyboardPayload)
             event = Event(type: .Custom,
                           data: AnyEventData(eventData),
                           timestamp: press.timestamp,
@@ -197,7 +200,10 @@ actor RRWebEventGenerator {
         } else {
             let remotePayload = RemoteControlPayload(
                 pressType: press.kind.sessionReplayWirePressType,
-                pressTypeSystemRaw: press.kind.sessionReplayUIPressTypeRawIfOther
+                pressTypeSystemRaw: press.kind.sessionReplayUIPressTypeRawIfOther,
+                target: press.target?.className ?? "",
+                textContent: press.target?.accessibilityIdentifier ?? "",
+                inputDevice: press.kind.sessionReplayInputDevice
             )
             let eventData = CustomEventData(tag: .remoteControl, payload: remotePayload)
             event = Event(type: .Custom,

--- a/Sources/LaunchDarklySessionReplay/Exporter/RRWebEventGenerator.swift
+++ b/Sources/LaunchDarklySessionReplay/Exporter/RRWebEventGenerator.swift
@@ -187,30 +187,28 @@ actor RRWebEventGenerator {
     
     private func appendPressInteraction(payload: PressInteractionPayload, events: inout [Event]) {
         let press = payload.pressInteraction
-        let event: Event
-        if press.isKeyboard {
-            let keyboardPayload = KeyboardPressPayload(
-                target: press.target?.className ?? ""
-            )
-            let eventData = CustomEventData(tag: .keyboardPress, payload: keyboardPayload)
-            event = Event(type: .Custom,
-                          data: AnyEventData(eventData),
-                          timestamp: press.timestamp,
-                          _sid: nextSid)
-        } else {
-            let remotePayload = RemoteControlPayload(
-                pressType: press.kind.sessionReplayWirePressType,
-                pressTypeSystemRaw: press.kind.sessionReplayUIPressTypeRawIfOther,
-                target: press.target?.className ?? "",
-                textContent: press.target?.accessibilityIdentifier ?? "",
-                inputDevice: press.kind.sessionReplayInputDevice
-            )
-            let eventData = CustomEventData(tag: .remoteControl, payload: remotePayload)
-            event = Event(type: .Custom,
-                          data: AnyEventData(eventData),
-                          timestamp: press.timestamp,
-                          _sid: nextSid)
+        let source: String
+        var pressType: String? = nil
+        var pressTypeSystemRaw: Int? = nil
+
+        switch press.kind {
+        case .keyboard:
+            source = "physical-keyboard"
+        case .untrackedWindowTouch:
+            source = "software-keyboard"
+        default:
+            source = "remote"
+            pressType = press.kind.sessionReplayWirePressType
+            pressTypeSystemRaw = press.kind.sessionReplayUIPressTypeRawIfOther
         }
+
+        let target = press.target?.className
+        let pressPayload = PressPayload(source: source, pressType: pressType, pressTypeSystemRaw: pressTypeSystemRaw, target: target)
+        let eventData = CustomEventData(tag: .press, payload: pressPayload)
+        let event = Event(type: .Custom,
+                          data: AnyEventData(eventData),
+                          timestamp: press.timestamp,
+                          _sid: nextSid)
         events.append(event)
     }
     

--- a/Sources/LaunchDarklySessionReplay/Exporter/RRWebEventGenerator.swift
+++ b/Sources/LaunchDarklySessionReplay/Exporter/RRWebEventGenerator.swift
@@ -133,6 +133,9 @@ actor RRWebEventGenerator {
                 events.append(event)
             }
             
+        case let tvPressItem as TVPressInteractionPayload:
+            appendTVPressInteraction(payload: tvPressItem, events: &events)
+            
         default:
             break // Item wasn't needed for SessionReplay
         }
@@ -179,6 +182,29 @@ actor RRWebEventGenerator {
         
         if let clickEvent = clickEvent(interaction: interaction) {
             events.append(clickEvent)
+        }
+    }
+    
+    private func appendTVPressInteraction(payload: TVPressInteractionPayload, events: inout [Event]) {
+        let pressInteraction = payload.pressInteraction
+        if pressInteraction.isKeyboardOriginated {
+            let keyboardPayload = KeyboardPressPayload(phase: pressInteraction.phase.sessionReplayWirePhase)
+            let eventData = CustomEventData(tag: .keyboardPress, payload: keyboardPayload)
+            events.append(Event(type: .Custom,
+                                 data: AnyEventData(eventData),
+                                 timestamp: pressInteraction.timestamp,
+                                 _sid: nextSid))
+        } else {
+            let remotePayload = RemoteControlPayload(
+                phase: pressInteraction.phase.sessionReplayWirePhase,
+                pressType: pressInteraction.kind.sessionReplayWirePressType,
+                pressTypeSystemRaw: pressInteraction.kind.sessionReplayUIPressTypeRawIfOther
+            )
+            let eventData = CustomEventData(tag: .remoteControl, payload: remotePayload)
+            events.append(Event(type: .Custom,
+                                 data: AnyEventData(eventData),
+                                 timestamp: pressInteraction.timestamp,
+                                 _sid: nextSid))
         }
     }
     

--- a/Sources/LaunchDarklySessionReplay/Exporter/SessionReplayPressWireFormat.swift
+++ b/Sources/LaunchDarklySessionReplay/Exporter/SessionReplayPressWireFormat.swift
@@ -25,16 +25,4 @@ extension RemotePressKind {
         if case .other(let raw) = self { return raw }
         return nil
     }
-
-    /// Coarse device category for `RemoteControl` payloads (no hardware identifiers). Not used for ``KeyboardPressPayload``.
-    var sessionReplayInputDevice: String {
-        switch self {
-        case .other:
-            return "unknown"
-        case .keyboard, .untrackedWindowTouch:
-            return "unknown"
-        default:
-            return "siriRemote"
-        }
-    }
 }

--- a/Sources/LaunchDarklySessionReplay/Exporter/SessionReplayPressWireFormat.swift
+++ b/Sources/LaunchDarklySessionReplay/Exporter/SessionReplayPressWireFormat.swift
@@ -1,0 +1,39 @@
+import Foundation
+import LaunchDarklyObservability
+
+extension PressInteraction.Phase {
+    var sessionReplayWirePhase: String {
+        switch self {
+        case .began: return "began"
+        case .changed: return "changed"
+        case .ended: return "ended"
+        case .cancelled: return "cancelled"
+        case .stationary: return "stationary"
+        }
+    }
+}
+
+extension RemotePressKind {
+    var sessionReplayWirePressType: String {
+        switch self {
+        case .upArrow: return "upArrow"
+        case .downArrow: return "downArrow"
+        case .leftArrow: return "leftArrow"
+        case .rightArrow: return "rightArrow"
+        case .select: return "select"
+        case .menu: return "menu"
+        case .playPause: return "playPause"
+        case .pageUp: return "pageUp"
+        case .pageDown: return "pageDown"
+        case .tvRemoteOneTwoThree: return "tvRemoteOneTwoThree"
+        case .tvRemoteFourColors: return "tvRemoteFourColors"
+        case .other: return "other"
+        case .untrackedWindowTouch: return "untrackedWindowTouch"
+        }
+    }
+
+    var sessionReplayUIPressTypeRawIfOther: Int? {
+        if case .other(let raw) = self { return raw }
+        return nil
+    }
+}

--- a/Sources/LaunchDarklySessionReplay/Exporter/SessionReplayPressWireFormat.swift
+++ b/Sources/LaunchDarklySessionReplay/Exporter/SessionReplayPressWireFormat.swift
@@ -1,18 +1,6 @@
 import Foundation
 import LaunchDarklyObservability
 
-extension PressInteraction.Phase {
-    var sessionReplayWirePhase: String {
-        switch self {
-        case .began: return "began"
-        case .changed: return "changed"
-        case .ended: return "ended"
-        case .cancelled: return "cancelled"
-        case .stationary: return "stationary"
-        }
-    }
-}
-
 extension RemotePressKind {
     var sessionReplayWirePressType: String {
         switch self {
@@ -27,8 +15,9 @@ extension RemotePressKind {
         case .pageDown: return "pageDown"
         case .tvRemoteOneTwoThree: return "tvRemoteOneTwoThree"
         case .tvRemoteFourColors: return "tvRemoteFourColors"
-        case .other: return "other"
+        case .keyboard: return "keyboard"
         case .untrackedWindowTouch: return "untrackedWindowTouch"
+        case .other: return "other"
         }
     }
 

--- a/Sources/LaunchDarklySessionReplay/Exporter/SessionReplayPressWireFormat.swift
+++ b/Sources/LaunchDarklySessionReplay/Exporter/SessionReplayPressWireFormat.swift
@@ -25,4 +25,16 @@ extension RemotePressKind {
         if case .other(let raw) = self { return raw }
         return nil
     }
+
+    /// Coarse device category for `RemoteControl` payloads (no hardware identifiers). Not used for ``KeyboardPressPayload``.
+    var sessionReplayInputDevice: String {
+        switch self {
+        case .other:
+            return "unknown"
+        case .keyboard, .untrackedWindowTouch:
+            return "unknown"
+        default:
+            return "siriRemote"
+        }
+    }
 }

--- a/Sources/LaunchDarklySessionReplay/Exporter/TVPressInteractionPayload.swift
+++ b/Sources/LaunchDarklySessionReplay/Exporter/TVPressInteractionPayload.swift
@@ -1,0 +1,18 @@
+import Foundation
+import LaunchDarklyObservability
+
+/// Queue item for non-spatial `PressInteraction` values (tvOS remote, filtered-window touches, keyboard-sourced presses).
+/// Encoded as RRWeb custom events (`RemoteControl`, `Keyboard`) by `RRWebEventGenerator`.
+struct TVPressInteractionPayload: EventQueueItemPayload {
+    let pressInteraction: PressInteraction
+
+    var timestamp: TimeInterval { pressInteraction.timestamp }
+
+    var exporterClass: AnyClass {
+        SessionReplayExporter.self
+    }
+
+    func cost() -> Int {
+        200
+    }
+}

--- a/Sources/LaunchDarklySessionReplay/RRWeb/CustomEventData.swift
+++ b/Sources/LaunchDarklySessionReplay/RRWeb/CustomEventData.swift
@@ -23,11 +23,60 @@ struct ClickPayload: Codable {
 
 /// Wire payload when the custom event tag is `RemoteControl` (`CustomDataTag.remoteControl.rawValue`).
 /// Backend / player: allowlist this tag if ingestion filters; optional `pressTypeSystemRaw` is only set for unmapped `UIPress.PressType` (`pressType` == `other`).
+/// `target` is the view class name; `textContent` matches ``ClickPayload.clickTextContent`` (typically accessibility identifier). `inputDevice` is a coarse category (e.g. `siriRemote`, `unknown`).
 struct RemoteControlPayload: Codable, Equatable {
     var pressType: String
     var pressTypeSystemRaw: Int?
+    var target: String
+    var textContent: String
+    var inputDevice: String
+
+    enum CodingKeys: String, CodingKey {
+        case pressType
+        case pressTypeSystemRaw
+        case target
+        case textContent
+        case inputDevice
+    }
+
+    init(
+        pressType: String,
+        pressTypeSystemRaw: Int? = nil,
+        target: String = "",
+        textContent: String = "",
+        inputDevice: String = ""
+    ) {
+        self.pressType = pressType
+        self.pressTypeSystemRaw = pressTypeSystemRaw
+        self.target = target
+        self.textContent = textContent
+        self.inputDevice = inputDevice
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        pressType = try c.decode(String.self, forKey: .pressType)
+        pressTypeSystemRaw = try c.decodeIfPresent(Int.self, forKey: .pressTypeSystemRaw)
+        target = try c.decodeIfPresent(String.self, forKey: .target) ?? ""
+        textContent = try c.decodeIfPresent(String.self, forKey: .textContent) ?? ""
+        inputDevice = try c.decodeIfPresent(String.self, forKey: .inputDevice) ?? ""
+    }
 }
 
-/// Wire payload when the custom event tag is `Keyboard` (`CustomDataTag.keyboardPress.rawValue`). No key identifiers or typed text.
+/// Wire payload when the custom event tag is `Keyboard` (`CustomDataTag.keyboardPress.rawValue`). `target` is the view class name; no key identifiers or typed text.
 struct KeyboardPressPayload: Codable, Equatable {
+    var target: String
+
+    enum CodingKeys: String, CodingKey {
+        case target
+    }
+
+    init(target: String = "") {
+        self.target = target
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        target = try c.decodeIfPresent(String.self, forKey: .target) ?? ""
+    }
 }

--- a/Sources/LaunchDarklySessionReplay/RRWeb/CustomEventData.swift
+++ b/Sources/LaunchDarklySessionReplay/RRWeb/CustomEventData.swift
@@ -20,3 +20,16 @@ struct ClickPayload: Codable {
     var clickTextContent: String
     var clickSelector: String
 }
+
+/// Wire payload when the custom event tag is `RemoteControl` (`CustomDataTag.remoteControl.rawValue`).
+/// Backend / player: allowlist this tag if ingestion filters; optional `pressTypeSystemRaw` is only set for unmapped `UIPress.PressType` (`pressType` == `other`).
+struct RemoteControlPayload: Codable, Equatable {
+    var phase: String
+    var pressType: String
+    var pressTypeSystemRaw: Int?
+}
+
+/// Wire payload when the custom event tag is `Keyboard` (`CustomDataTag.keyboardPress.rawValue`). Phase only — never key identifiers or typed text.
+struct KeyboardPressPayload: Codable, Equatable {
+    var phase: String
+}

--- a/Sources/LaunchDarklySessionReplay/RRWeb/CustomEventData.swift
+++ b/Sources/LaunchDarklySessionReplay/RRWeb/CustomEventData.swift
@@ -21,62 +21,12 @@ struct ClickPayload: Codable {
     var clickSelector: String
 }
 
-/// Wire payload when the custom event tag is `RemoteControl` (`CustomDataTag.remoteControl.rawValue`).
-/// Backend / player: allowlist this tag if ingestion filters; optional `pressTypeSystemRaw` is only set for unmapped `UIPress.PressType` (`pressType` == `other`).
-/// `target` is the view class name; `textContent` matches ``ClickPayload.clickTextContent`` (typically accessibility identifier). `inputDevice` is a coarse category (e.g. `siriRemote`, `unknown`).
-struct RemoteControlPayload: Codable, Equatable {
-    var pressType: String
+/// Unified wire payload for `CustomDataTag.press` (`"Press"`).
+/// `source` discriminates input origin: `"remote"`, `"physical-keyboard"`, or `"software-keyboard"`.
+/// `pressType` and `pressTypeSystemRaw` are only set when `source == "remote"`.
+struct PressPayload: Codable, Equatable {
+    var source: String
+    var pressType: String?
     var pressTypeSystemRaw: Int?
-    var target: String
-    var textContent: String
-    var inputDevice: String
-
-    enum CodingKeys: String, CodingKey {
-        case pressType
-        case pressTypeSystemRaw
-        case target
-        case textContent
-        case inputDevice
-    }
-
-    init(
-        pressType: String,
-        pressTypeSystemRaw: Int? = nil,
-        target: String = "",
-        textContent: String = "",
-        inputDevice: String = ""
-    ) {
-        self.pressType = pressType
-        self.pressTypeSystemRaw = pressTypeSystemRaw
-        self.target = target
-        self.textContent = textContent
-        self.inputDevice = inputDevice
-    }
-
-    init(from decoder: Decoder) throws {
-        let c = try decoder.container(keyedBy: CodingKeys.self)
-        pressType = try c.decode(String.self, forKey: .pressType)
-        pressTypeSystemRaw = try c.decodeIfPresent(Int.self, forKey: .pressTypeSystemRaw)
-        target = try c.decodeIfPresent(String.self, forKey: .target) ?? ""
-        textContent = try c.decodeIfPresent(String.self, forKey: .textContent) ?? ""
-        inputDevice = try c.decodeIfPresent(String.self, forKey: .inputDevice) ?? ""
-    }
-}
-
-/// Wire payload when the custom event tag is `Keyboard` (`CustomDataTag.keyboardPress.rawValue`). `target` is the view class name; no key identifiers or typed text.
-struct KeyboardPressPayload: Codable, Equatable {
-    var target: String
-
-    enum CodingKeys: String, CodingKey {
-        case target
-    }
-
-    init(target: String = "") {
-        self.target = target
-    }
-
-    init(from decoder: Decoder) throws {
-        let c = try decoder.container(keyedBy: CodingKeys.self)
-        target = try c.decodeIfPresent(String.self, forKey: .target) ?? ""
-    }
+    var target: String?
 }

--- a/Sources/LaunchDarklySessionReplay/RRWeb/CustomEventData.swift
+++ b/Sources/LaunchDarklySessionReplay/RRWeb/CustomEventData.swift
@@ -24,12 +24,10 @@ struct ClickPayload: Codable {
 /// Wire payload when the custom event tag is `RemoteControl` (`CustomDataTag.remoteControl.rawValue`).
 /// Backend / player: allowlist this tag if ingestion filters; optional `pressTypeSystemRaw` is only set for unmapped `UIPress.PressType` (`pressType` == `other`).
 struct RemoteControlPayload: Codable, Equatable {
-    var phase: String
     var pressType: String
     var pressTypeSystemRaw: Int?
 }
 
-/// Wire payload when the custom event tag is `Keyboard` (`CustomDataTag.keyboardPress.rawValue`). Phase only — never key identifiers or typed text.
+/// Wire payload when the custom event tag is `Keyboard` (`CustomDataTag.keyboardPress.rawValue`). No key identifiers or typed text.
 struct KeyboardPressPayload: Codable, Equatable {
-    var phase: String
 }

--- a/Sources/LaunchDarklySessionReplay/RRWeb/Event.swift
+++ b/Sources/LaunchDarklySessionReplay/RRWeb/Event.swift
@@ -48,10 +48,8 @@ struct AnyEventData: Codable {
                 try CustomEventData<ViewportPayload>(from: decoder)
             case .reload:
                 try CustomEventData<String>(from: decoder)
-            case .remoteControl:
-                try CustomEventData<RemoteControlPayload>(from: decoder)
-            case .keyboardPress:
-                try CustomEventData<KeyboardPressPayload>(from: decoder)
+            case .press:
+                try CustomEventData<PressPayload>(from: decoder)
             }
         } else {
             throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: [], debugDescription: "Unexpected EventData"))

--- a/Sources/LaunchDarklySessionReplay/RRWeb/Event.swift
+++ b/Sources/LaunchDarklySessionReplay/RRWeb/Event.swift
@@ -48,6 +48,10 @@ struct AnyEventData: Codable {
                 try CustomEventData<ViewportPayload>(from: decoder)
             case .reload:
                 try CustomEventData<String>(from: decoder)
+            case .remoteControl:
+                try CustomEventData<RemoteControlPayload>(from: decoder)
+            case .keyboardPress:
+                try CustomEventData<KeyboardPressPayload>(from: decoder)
             }
         } else {
             throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: [], debugDescription: "Unexpected EventData"))

--- a/Sources/LaunchDarklySessionReplay/RRWeb/RRWebTypes.swift
+++ b/Sources/LaunchDarklySessionReplay/RRWeb/RRWebTypes.swift
@@ -53,10 +53,20 @@ enum MouseInteractions: Int, Codable {
          touchCancel = 10
 }
 
+/// Custom event `tag` strings on RRWeb `EventType.custom` payloads.
+///
+/// **Player / backend contract**
+/// - Tags and JSON payload shapes below are the integration surface for the session replay web player and GraphQL ingestion.
+/// - Ingestion that allowlists `tag` must include any tag you rely on; unknown tags should be stored opaquely or ignored per product policy.
+/// - The RRWeb replayer ignores unknown custom tags unless extended on the web side.
 enum CustomDataTag: String, Codable {
     case click = "Click"
     case focus = "Focus"
     case viewport = "Viewport"
     case reload = "Reload"
     case identify = "Identify"
+    /// Siri Remote, game controller, D-pad, or filtered-window touch without coordinates. Payload: `RemoteControlPayload`.
+    case remoteControl = "RemoteControl"
+    /// Hardware keyboard (`UIPress.key`); presses that are not emitted with the `RemoteControl` tag use this tag. Payload: `KeyboardPressPayload` (phase only).
+    case keyboardPress = "Keyboard"
 }

--- a/Sources/LaunchDarklySessionReplay/RRWeb/RRWebTypes.swift
+++ b/Sources/LaunchDarklySessionReplay/RRWeb/RRWebTypes.swift
@@ -65,8 +65,6 @@ enum CustomDataTag: String, Codable {
     case viewport = "Viewport"
     case reload = "Reload"
     case identify = "Identify"
-    /// Siri Remote, game controller, D-pad, or filtered-window touch without coordinates. Payload: `RemoteControlPayload`.
-    case remoteControl = "RemoteControl"
-    /// Hardware keyboard (`UIPress.key`); presses that are not emitted with the `RemoteControl` tag use this tag. Payload: `KeyboardPressPayload`.
-    case keyboardPress = "Keyboard"
+    /// Non-spatial press: remote control, physical keyboard, or software keyboard. Payload: `PressPayload` with `source` discriminator.
+    case press = "Press"
 }

--- a/Sources/LaunchDarklySessionReplay/RRWeb/RRWebTypes.swift
+++ b/Sources/LaunchDarklySessionReplay/RRWeb/RRWebTypes.swift
@@ -67,6 +67,6 @@ enum CustomDataTag: String, Codable {
     case identify = "Identify"
     /// Siri Remote, game controller, D-pad, or filtered-window touch without coordinates. Payload: `RemoteControlPayload`.
     case remoteControl = "RemoteControl"
-    /// Hardware keyboard (`UIPress.key`); presses that are not emitted with the `RemoteControl` tag use this tag. Payload: `KeyboardPressPayload` (phase only).
+    /// Hardware keyboard (`UIPress.key`); presses that are not emitted with the `RemoteControl` tag use this tag. Payload: `KeyboardPressPayload`.
     case keyboardPress = "Keyboard"
 }

--- a/Sources/LaunchDarklySessionReplay/SessionReplayService.swift
+++ b/Sources/LaunchDarklySessionReplay/SessionReplayService.swift
@@ -135,10 +135,15 @@ final class SessionReplayService: SessionReplayServicing {
     
     @MainActor
     private func internalStart() {
-        userInteractionManager.publisher
-            .sink { [transportService] interaction in
+        userInteractionManager.interactionEvents
+            .sink { [transportService] event in
                 Task {
-                    await transportService.eventQueue.send(interaction)
+                    switch event {
+                    case .touch(let interaction):
+                        await transportService.eventQueue.send(interaction)
+                    case .press(let pressInteraction):
+                        await transportService.eventQueue.send(TVPressInteractionPayload(pressInteraction: pressInteraction))
+                    }
                 }
             }
             .store(in: &cancellables)

--- a/Sources/LaunchDarklySessionReplay/SessionReplayService.swift
+++ b/Sources/LaunchDarklySessionReplay/SessionReplayService.swift
@@ -142,7 +142,7 @@ final class SessionReplayService: SessionReplayServicing {
                     case .touch(let interaction):
                         await transportService.eventQueue.send(interaction)
                     case .press(let pressInteraction):
-                        await transportService.eventQueue.send(TVPressInteractionPayload(pressInteraction: pressInteraction))
+                        await transportService.eventQueue.send(PressInteractionPayload(pressInteraction: pressInteraction))
                     }
                 }
             }

--- a/TestApp/Sources/MainMenuViewModel.swift
+++ b/TestApp/Sources/MainMenuViewModel.swift
@@ -6,10 +6,7 @@ final class MainMenuViewModel: ObservableObject {
 	@Published var isNetworkInProgress: Bool = false
 	
 	func recordError() {
-		LDObserve.shared.recordError(
-			error: Failure.crash,
-			attributes: [:]
-		)
+		LDObserve.shared.recordError(Failure.crash, attributes: [:])
 	}
 	
 	func recordSpanAndVariation() {

--- a/Tests/SessionReplayTests/RRWebEventGeneratorTests.swift
+++ b/Tests/SessionReplayTests/RRWebEventGeneratorTests.swift
@@ -150,7 +150,7 @@ struct RRWebEventGeneratorTests {
             target: nil,
             isKeyboardOriginated: false
         )
-        let items: [EventQueueItem] = [EventQueueItem(payload: TVPressInteractionPayload(pressInteraction: pressInteraction))]
+        let items: [EventQueueItem] = [EventQueueItem(payload: PressInteractionPayload(pressInteraction: pressInteraction))]
         let events = await generator.generateEvents(items: items)
         #expect(events.count == 1)
         #expect(events[0].type == .Custom)
@@ -178,7 +178,7 @@ struct RRWebEventGeneratorTests {
             target: nil,
             isKeyboardOriginated: true
         )
-        let items: [EventQueueItem] = [EventQueueItem(payload: TVPressInteractionPayload(pressInteraction: pressInteraction))]
+        let items: [EventQueueItem] = [EventQueueItem(payload: PressInteractionPayload(pressInteraction: pressInteraction))]
         let events = await generator.generateEvents(items: items)
         #expect(events.count == 1)
         #expect(events[0].type == .Custom)
@@ -188,6 +188,32 @@ struct RRWebEventGeneratorTests {
         #expect(data?["tag"] as? String == "Keyboard")
         let payload = data?["payload"] as? [String: Any]
         #expect(payload?["phase"] as? String == "ended")
+    }
+    
+    @Test("Appends Keyboard custom event for untracked window touch")
+    func appendsKeyboardEventForUntrackedWindowTouch() async throws {
+        let generator = RRWebEventGenerator(
+            log: OSLog(subsystem: "test", category: "test"),
+            title: "Test",
+            method: .overlayTiles()
+        )
+        let pressInteraction = PressInteraction(
+            phase: .began,
+            kind: .untrackedWindowTouch,
+            timestamp: 50.0,
+            target: nil,
+            isKeyboardOriginated: true
+        )
+        let items: [EventQueueItem] = [EventQueueItem(payload: PressInteractionPayload(pressInteraction: pressInteraction))]
+        let events = await generator.generateEvents(items: items)
+        #expect(events.count == 1)
+        #expect(events[0].type == .Custom)
+        let encoded = try JSONEncoder().encode(events[0])
+        let json = try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        let data = json?["data"] as? [String: Any]
+        #expect(data?["tag"] as? String == "Keyboard")
+        let payload = data?["payload"] as? [String: Any]
+        #expect(payload?["phase"] as? String == "began")
     }
     
     @Test("RemoteControl custom event decodes via AnyEventData")

--- a/Tests/SessionReplayTests/RRWebEventGeneratorTests.swift
+++ b/Tests/SessionReplayTests/RRWebEventGeneratorTests.swift
@@ -136,8 +136,8 @@ struct RRWebEventGeneratorTests {
         #expect(events[3].type == .IncrementalSnapshot)
     }
     
-    @Test("Appends RemoteControl custom event for non-keyboard press interaction")
-    func appendsRemoteControlCustomEvent() async throws {
+    @Test("Appends Press event with source remote for remote press interaction")
+    func appendsPressRemoteEvent() async throws {
         let generator = RRWebEventGenerator(
             log: OSLog(subsystem: "test", category: "test"),
             title: "Test",
@@ -156,24 +156,22 @@ struct RRWebEventGeneratorTests {
         let encoded = try JSONEncoder().encode(events[0])
         let json = try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
         let data = json?["data"] as? [String: Any]
-        #expect(data?["tag"] as? String == "RemoteControl")
+        #expect(data?["tag"] as? String == "Press")
         let payload = data?["payload"] as? [String: Any]
+        #expect(payload?["source"] as? String == "remote")
         #expect(payload?["pressType"] as? String == "select")
         #expect(payload?["pressTypeSystemRaw"] == nil)
-        #expect(payload?["target"] as? String == "")
-        #expect(payload?["textContent"] as? String == "")
-        #expect(payload?["inputDevice"] as? String == "siriRemote")
     }
-    
-    @Test("Appends Keyboard custom event for keyboard kind")
-    func appendsKeyboardPressCustomEvent() async throws {
+
+    @Test("Appends Press event with source physical-keyboard for keyboard kind")
+    func appendsPressPhysicalKeyboardEvent() async throws {
         let generator = RRWebEventGenerator(
             log: OSLog(subsystem: "test", category: "test"),
             title: "Test",
             method: .overlayTiles()
         )
         let pressInteraction = PressInteraction(
-            phase: .ended,
+            phase: .began,
             kind: .keyboard,
             timestamp: 12.0,
             target: nil
@@ -185,13 +183,14 @@ struct RRWebEventGeneratorTests {
         let encoded = try JSONEncoder().encode(events[0])
         let json = try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
         let data = json?["data"] as? [String: Any]
-        #expect(data?["tag"] as? String == "Keyboard")
+        #expect(data?["tag"] as? String == "Press")
         let payload = data?["payload"] as? [String: Any]
-        #expect(payload?["target"] as? String == "")
+        #expect(payload?["source"] as? String == "physical-keyboard")
+        #expect(payload?["pressType"] == nil)
     }
-    
-    @Test("Appends Keyboard custom event for untracked window touch")
-    func appendsKeyboardEventForUntrackedWindowTouch() async throws {
+
+    @Test("Appends Press event with source software-keyboard for untracked window touch")
+    func appendsPressSoftwareKeyboardEvent() async throws {
         let generator = RRWebEventGenerator(
             log: OSLog(subsystem: "test", category: "test"),
             title: "Test",
@@ -210,15 +209,16 @@ struct RRWebEventGeneratorTests {
         let encoded = try JSONEncoder().encode(events[0])
         let json = try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
         let data = json?["data"] as? [String: Any]
-        #expect(data?["tag"] as? String == "Keyboard")
+        #expect(data?["tag"] as? String == "Press")
         let payload = data?["payload"] as? [String: Any]
-        #expect(payload?["target"] as? String == "")
+        #expect(payload?["source"] as? String == "software-keyboard")
+        #expect(payload?["pressType"] == nil)
     }
-    
-    @Test("RemoteControl custom event decodes via AnyEventData")
-    func remoteControlEventDecodesRoundTrip() throws {
-        let payload = RemoteControlPayload(pressType: "other", pressTypeSystemRaw: 77)
-        let custom = CustomEventData(tag: .remoteControl, payload: payload)
+
+    @Test("Press custom event decodes via AnyEventData round-trip")
+    func pressEventDecodesRoundTrip() throws {
+        let payload = PressPayload(source: "remote", pressType: "other", pressTypeSystemRaw: 77)
+        let custom = CustomEventData(tag: .press, payload: payload)
         let event = Event(type: .Custom, data: AnyEventData(custom), timestamp: 10.0, _sid: 1)
         let encoded = try JSONEncoder().encode(event)
         let decoded = try JSONDecoder().decode(Event.self, from: encoded)
@@ -226,12 +226,11 @@ struct RRWebEventGeneratorTests {
         let roundTrip = try JSONEncoder().encode(decoded)
         let json = try JSONSerialization.jsonObject(with: roundTrip) as? [String: Any]
         let data = json?["data"] as? [String: Any]
-        #expect(data?["tag"] as? String == "RemoteControl")
+        #expect(data?["tag"] as? String == "Press")
         let p = data?["payload"] as? [String: Any]
+        #expect(p?["source"] as? String == "remote")
+        #expect(p?["pressType"] as? String == "other")
         #expect(p?["pressTypeSystemRaw"] as? Int == 77)
-        #expect(p?["target"] as? String == "")
-        #expect(p?["textContent"] as? String == "")
-        #expect(p?["inputDevice"] as? String == "")
     }
 }
 

--- a/Tests/SessionReplayTests/RRWebEventGeneratorTests.swift
+++ b/Tests/SessionReplayTests/RRWebEventGeneratorTests.swift
@@ -160,6 +160,9 @@ struct RRWebEventGeneratorTests {
         let payload = data?["payload"] as? [String: Any]
         #expect(payload?["pressType"] as? String == "select")
         #expect(payload?["pressTypeSystemRaw"] == nil)
+        #expect(payload?["target"] as? String == "")
+        #expect(payload?["textContent"] as? String == "")
+        #expect(payload?["inputDevice"] as? String == "siriRemote")
     }
     
     @Test("Appends Keyboard custom event for keyboard kind")
@@ -183,6 +186,8 @@ struct RRWebEventGeneratorTests {
         let json = try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
         let data = json?["data"] as? [String: Any]
         #expect(data?["tag"] as? String == "Keyboard")
+        let payload = data?["payload"] as? [String: Any]
+        #expect(payload?["target"] as? String == "")
     }
     
     @Test("Appends Keyboard custom event for untracked window touch")
@@ -206,6 +211,8 @@ struct RRWebEventGeneratorTests {
         let json = try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
         let data = json?["data"] as? [String: Any]
         #expect(data?["tag"] as? String == "Keyboard")
+        let payload = data?["payload"] as? [String: Any]
+        #expect(payload?["target"] as? String == "")
     }
     
     @Test("RemoteControl custom event decodes via AnyEventData")
@@ -222,6 +229,9 @@ struct RRWebEventGeneratorTests {
         #expect(data?["tag"] as? String == "RemoteControl")
         let p = data?["payload"] as? [String: Any]
         #expect(p?["pressTypeSystemRaw"] as? Int == 77)
+        #expect(p?["target"] as? String == "")
+        #expect(p?["textContent"] as? String == "")
+        #expect(p?["inputDevice"] as? String == "")
     }
 }
 

--- a/Tests/SessionReplayTests/RRWebEventGeneratorTests.swift
+++ b/Tests/SessionReplayTests/RRWebEventGeneratorTests.swift
@@ -147,8 +147,7 @@ struct RRWebEventGeneratorTests {
             phase: .began,
             kind: .select,
             timestamp: 99.0,
-            target: nil,
-            isKeyboardOriginated: false
+            target: nil
         )
         let items: [EventQueueItem] = [EventQueueItem(payload: PressInteractionPayload(pressInteraction: pressInteraction))]
         let events = await generator.generateEvents(items: items)
@@ -159,12 +158,11 @@ struct RRWebEventGeneratorTests {
         let data = json?["data"] as? [String: Any]
         #expect(data?["tag"] as? String == "RemoteControl")
         let payload = data?["payload"] as? [String: Any]
-        #expect(payload?["phase"] as? String == "began")
         #expect(payload?["pressType"] as? String == "select")
         #expect(payload?["pressTypeSystemRaw"] == nil)
     }
     
-    @Test("Appends Keyboard custom event when press is keyboard-originated")
+    @Test("Appends Keyboard custom event for keyboard kind")
     func appendsKeyboardPressCustomEvent() async throws {
         let generator = RRWebEventGenerator(
             log: OSLog(subsystem: "test", category: "test"),
@@ -173,10 +171,9 @@ struct RRWebEventGeneratorTests {
         )
         let pressInteraction = PressInteraction(
             phase: .ended,
-            kind: .select,
+            kind: .keyboard,
             timestamp: 12.0,
-            target: nil,
-            isKeyboardOriginated: true
+            target: nil
         )
         let items: [EventQueueItem] = [EventQueueItem(payload: PressInteractionPayload(pressInteraction: pressInteraction))]
         let events = await generator.generateEvents(items: items)
@@ -186,8 +183,6 @@ struct RRWebEventGeneratorTests {
         let json = try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
         let data = json?["data"] as? [String: Any]
         #expect(data?["tag"] as? String == "Keyboard")
-        let payload = data?["payload"] as? [String: Any]
-        #expect(payload?["phase"] as? String == "ended")
     }
     
     @Test("Appends Keyboard custom event for untracked window touch")
@@ -201,8 +196,7 @@ struct RRWebEventGeneratorTests {
             phase: .began,
             kind: .untrackedWindowTouch,
             timestamp: 50.0,
-            target: nil,
-            isKeyboardOriginated: true
+            target: nil
         )
         let items: [EventQueueItem] = [EventQueueItem(payload: PressInteractionPayload(pressInteraction: pressInteraction))]
         let events = await generator.generateEvents(items: items)
@@ -212,13 +206,11 @@ struct RRWebEventGeneratorTests {
         let json = try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
         let data = json?["data"] as? [String: Any]
         #expect(data?["tag"] as? String == "Keyboard")
-        let payload = data?["payload"] as? [String: Any]
-        #expect(payload?["phase"] as? String == "began")
     }
     
     @Test("RemoteControl custom event decodes via AnyEventData")
     func remoteControlEventDecodesRoundTrip() throws {
-        let payload = RemoteControlPayload(phase: "began", pressType: "other", pressTypeSystemRaw: 77)
+        let payload = RemoteControlPayload(pressType: "other", pressTypeSystemRaw: 77)
         let custom = CustomEventData(tag: .remoteControl, payload: payload)
         let event = Event(type: .Custom, data: AnyEventData(custom), timestamp: 10.0, _sid: 1)
         let encoded = try JSONEncoder().encode(event)

--- a/Tests/SessionReplayTests/RRWebEventGeneratorTests.swift
+++ b/Tests/SessionReplayTests/RRWebEventGeneratorTests.swift
@@ -1,8 +1,9 @@
 import Testing
 @testable import LaunchDarklySessionReplay
-import LaunchDarklyObservability
+@testable import LaunchDarklyObservability
 import OSLog
 import CoreGraphics
+import Foundation
 
 struct RRWebEventGeneratorTests {
     
@@ -133,6 +134,76 @@ struct RRWebEventGeneratorTests {
         #expect(events[1].type == .FullSnapshot)
         #expect(events[2].type == .Custom)
         #expect(events[3].type == .IncrementalSnapshot)
+    }
+    
+    @Test("Appends RemoteControl custom event for non-keyboard press interaction")
+    func appendsRemoteControlCustomEvent() async throws {
+        let generator = RRWebEventGenerator(
+            log: OSLog(subsystem: "test", category: "test"),
+            title: "Test",
+            method: .overlayTiles()
+        )
+        let pressInteraction = PressInteraction(
+            phase: .began,
+            kind: .select,
+            timestamp: 99.0,
+            target: nil,
+            isKeyboardOriginated: false
+        )
+        let items: [EventQueueItem] = [EventQueueItem(payload: TVPressInteractionPayload(pressInteraction: pressInteraction))]
+        let events = await generator.generateEvents(items: items)
+        #expect(events.count == 1)
+        #expect(events[0].type == .Custom)
+        let encoded = try JSONEncoder().encode(events[0])
+        let json = try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        let data = json?["data"] as? [String: Any]
+        #expect(data?["tag"] as? String == "RemoteControl")
+        let payload = data?["payload"] as? [String: Any]
+        #expect(payload?["phase"] as? String == "began")
+        #expect(payload?["pressType"] as? String == "select")
+        #expect(payload?["pressTypeSystemRaw"] == nil)
+    }
+    
+    @Test("Appends Keyboard custom event when press is keyboard-originated")
+    func appendsKeyboardPressCustomEvent() async throws {
+        let generator = RRWebEventGenerator(
+            log: OSLog(subsystem: "test", category: "test"),
+            title: "Test",
+            method: .overlayTiles()
+        )
+        let pressInteraction = PressInteraction(
+            phase: .ended,
+            kind: .select,
+            timestamp: 12.0,
+            target: nil,
+            isKeyboardOriginated: true
+        )
+        let items: [EventQueueItem] = [EventQueueItem(payload: TVPressInteractionPayload(pressInteraction: pressInteraction))]
+        let events = await generator.generateEvents(items: items)
+        #expect(events.count == 1)
+        #expect(events[0].type == .Custom)
+        let encoded = try JSONEncoder().encode(events[0])
+        let json = try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        let data = json?["data"] as? [String: Any]
+        #expect(data?["tag"] as? String == "Keyboard")
+        let payload = data?["payload"] as? [String: Any]
+        #expect(payload?["phase"] as? String == "ended")
+    }
+    
+    @Test("RemoteControl custom event decodes via AnyEventData")
+    func remoteControlEventDecodesRoundTrip() throws {
+        let payload = RemoteControlPayload(phase: "began", pressType: "other", pressTypeSystemRaw: 77)
+        let custom = CustomEventData(tag: .remoteControl, payload: payload)
+        let event = Event(type: .Custom, data: AnyEventData(custom), timestamp: 10.0, _sid: 1)
+        let encoded = try JSONEncoder().encode(event)
+        let decoded = try JSONDecoder().decode(Event.self, from: encoded)
+        #expect(decoded.type == .Custom)
+        let roundTrip = try JSONEncoder().encode(decoded)
+        let json = try JSONSerialization.jsonObject(with: roundTrip) as? [String: Any]
+        let data = json?["data"] as? [String: Any]
+        #expect(data?["tag"] as? String == "RemoteControl")
+        let p = data?["payload"] as? [String: Any]
+        #expect(p?["pressTypeSystemRaw"] as? Int == 77)
     }
 }
 


### PR DESCRIPTION
## Summary

Extends session replay to capture non-spatial press interactions (tvOS Siri Remote, D-pad, hardware keyboard, keyboard-window touches) and encode them as RRWeb custom events alongside existing touch replay.

### What changed

**Capture layer (`LaunchDarklyObservability`)**

- `PressInteraction` — replaces `PressSample`; adds `.keyboard` kind for hardware keyboard presses; `isKeyboard` computed property covers `.keyboard` and `.untrackedWindowTouch`
- `InteractionEvent` — unified `.touch` / `.press` enum replacing the old touch-only `PassthroughSubject`
- `UserInteractionManager` — single `interactionEvents` publisher replaces the old `publisher` + separate subject
- `InputCaptureCoordinator` — press events emitted on `.began` only (no redundant `.ended`); `.other` kind filtered out but `.keyboard` passes through
- `PressInterpreter` — converts `UIPress`/`UITouch` system-uptime timestamps to Unix epoch (same approach as `TouchInterpreter`)

**Transport layer (`LaunchDarklySessionReplay`)**

- `PressInteractionPayload` — `EventQueueItemPayload` with `SessionReplayExporter`; routes through the same `EventQueue` as touches
- `SessionReplayService` — subscribes to `interactionEvents`, dispatching touches and presses into the queue

### RRWeb wire contract

| Tag | When | Payload |
|---|---|---|
| `RemoteControl` | Siri Remote, D-pad, game controller press | `{ "pressType": "select" }` (+ optional `pressTypeSystemRaw`) |
| `Keyboard` | Hardware keyboard key or keyboard-window touch | `{}` (empty — tag carries the semantics) |

Both are `EventType.Custom` (type 5). Backend stores them as opaque JSON. Web player ignores unknown tags unless extended.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new interaction type and RRWeb custom event encoding for keyboard/remote presses, changing the session replay event stream and wire payloads. Risk is moderate due to potential compatibility issues with downstream ingestion/player expectations and timestamp conversion logic.
> 
> **Overview**
> Session replay now captures *non-spatial press interactions* (remote controls, hardware keyboard presses, and touches on untracked windows like keyboard chrome) and exports them alongside existing touch replay.
> 
> On the capture side, `PressSample` is replaced by `PressInteraction` (including a new `.keyboard` kind) and a new `PressInterpreter` normalizes press timestamps to Unix time; press/touch forwarding is unified via an ordered `InteractionEvent` stream from `UserInteractionManager`.
> 
> On the export side, presses are queued via `PressInteractionPayload` and encoded by `RRWebEventGenerator` as a new RRWeb custom tag `Press` with a `PressPayload` that records the press `source` (remote vs physical/software keyboard) plus optional remote `pressType`/raw type; decoding support and tests were added for this new custom event.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e964ca1a280fbcf9866c7442d413a7444559c651. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->