### PR TITLE
feat: verbatim session for external session id

### DIFF
--- a/ExampleApp/ExampleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ExampleApp/ExampleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/launchdarkly/ios-client-sdk.git",
       "state" : {
-        "revision" : "34d1a543471753c3a51339af79c12389ca0e6b46",
-        "version" : "11.1.0"
+        "revision" : "8b56cf8a7f74618a5d8e9ef0e4dad543e2f3fed7",
+        "version" : "11.1.1"
       }
     },
     {

--- a/ExampleApp/ExampleApp/Instrumentation/Manual/TraceView.swift
+++ b/ExampleApp/ExampleApp/Instrumentation/Manual/TraceView.swift
@@ -51,7 +51,7 @@ struct TraceView: View {
             VStack(spacing: 16.0) {
                 Button {
                     LDObserve.shared.recordError(
-                        error: SampleError.error1,
+                        SampleError.error1,
                         attributes: [:]
                     )
                 } label: {
@@ -61,7 +61,7 @@ struct TraceView: View {
                 .buttonStyle(.borderedProminent)
                 Button {
                     LDObserve.shared.recordError(
-                        error: SampleError.error2,
+                        SampleError.error2,
                         attributes: [:]
                     )
                 } label: {

--- a/Sources/LaunchDarklyObservability/Client/ObservabilityService.swift
+++ b/Sources/LaunchDarklyObservability/Client/ObservabilityService.swift
@@ -313,9 +313,11 @@ extension ObservabilityService {
             task = Task { [weak self] in
                 guard let self else { return }
                 let id = SessionIdResolver.resolve(sessionId: sessionId, log: options.log)
+                // Invalid IDs are replaced with a generated value; only keep "custom" when we actually use the caller's ID.
+                let effectiveIsCustomSession = isCustomSession && (id == sessionId)
 
                 do {
-                    self.context?.sessionManager.start(sessionId: id, isCustomSession: isCustomSession)
+                    self.context?.sessionManager.start(sessionId: id, isCustomSession: effectiveIsCustomSession)
                     try await self.start()
                 } catch {
                     os_log("%{public}@", log: options.log, type: .error, "Failure starting Observability Service: \(error)")

--- a/Sources/LaunchDarklyObservability/Client/ObservabilityService.swift
+++ b/Sources/LaunchDarklyObservability/Client/ObservabilityService.swift
@@ -313,11 +313,9 @@ extension ObservabilityService {
             task = Task { [weak self] in
                 guard let self else { return }
                 let id = SessionIdResolver.resolve(sessionId: sessionId, log: options.log)
-                // Invalid IDs are replaced with a generated value; only keep "custom" when we actually use the caller's ID.
-                let effectiveIsCustomSession = isCustomSession && (id == sessionId)
 
                 do {
-                    self.context?.sessionManager.start(sessionId: id, isCustomSession: effectiveIsCustomSession)
+                    self.context?.sessionManager.start(sessionId: id, isCustomSession: isCustomSession)
                     try await self.start()
                 } catch {
                     os_log("%{public}@", log: options.log, type: .error, "Failure starting Observability Service: \(error)")

--- a/Sources/LaunchDarklyObservability/Client/ObservabilityService.swift
+++ b/Sources/LaunchDarklyObservability/Client/ObservabilityService.swift
@@ -300,6 +300,14 @@ extension ObservabilityService {
 
 extension ObservabilityService {
     func start(sessionId: String) {
+        startSession(sessionId: sessionId, isCustomSession: true)
+    }
+
+    func start() {
+        startSession(sessionId: SecureIDGenerator.generateSecureID(), isCustomSession: false)
+    }
+
+    private func startSession(sessionId: String, isCustomSession: Bool) {
         startQueue.sync {
             guard task == nil else { return }
             task = Task { [weak self] in
@@ -307,17 +315,13 @@ extension ObservabilityService {
                 let id = SessionIdResolver.resolve(sessionId: sessionId, log: options.log)
 
                 do {
-                    self.context?.sessionManager.start(sessionId: id)
+                    self.context?.sessionManager.start(sessionId: id, isCustomSession: isCustomSession)
                     try await self.start()
                 } catch {
                     os_log("%{public}@", log: options.log, type: .error, "Failure starting Observability Service: \(error)")
                 }
             }
         }
-    }
-
-    func start() {
-        start(sessionId: SecureIDGenerator.generateSecureID())
     }
 }
 

--- a/Sources/LaunchDarklyObservability/Session/SessionManager.swift
+++ b/Sources/LaunchDarklyObservability/Session/SessionManager.swift
@@ -14,7 +14,7 @@ public protocol SessionManaging {
 
 extension SessionManaging {
     func start(sessionId: String) {
-        start(sessionId: sessionId, isCustomSession: false)
+        start(sessionId: sessionId, isCustomSession: true)
     }
 }
 

--- a/Sources/LaunchDarklyObservability/Session/SessionManager.swift
+++ b/Sources/LaunchDarklyObservability/Session/SessionManager.swift
@@ -8,8 +8,14 @@ import OSLog
 
 public protocol SessionManaging {
     func publisher() -> AnyPublisher<SessionInfo, Never>
-    func start(sessionId: String)
+    func start(sessionId: String, isCustomSession: Bool)
     var sessionInfo: SessionInfo { get }
+}
+
+extension SessionManaging {
+    func start(sessionId: String) {
+        start(sessionId: sessionId, isCustomSession: false)
+    }
 }
 
 final class SessionManager: SessionManaging {
@@ -17,6 +23,7 @@ final class SessionManager: SessionManaging {
     private let options: SessionOptions
     private let subject = PassthroughSubject<SessionInfo, Never>()
     private var _sessionInfo = SessionInfo()
+    private var _isCustomSession: Bool = false
     private var backgroundTime: DispatchTime?
     private var cancellables = Set<AnyCancellable>()
     private let cancellablesQueue = DispatchQueue(label: "com.launchdarkly.observability.cancellables")
@@ -64,6 +71,7 @@ final class SessionManager: SessionManaging {
     private func handleActiveState() {
         stateQueue.sync(flags: .barrier) { [weak self] in
             guard let self else { return }
+            guard !self._isCustomSession else { return }
 
             guard let backgroundTime = self.backgroundTime else { return }
             let timeInBackground = Double(DispatchTime.now().uptimeNanoseconds - backgroundTime.uptimeNanoseconds) / Double(NSEC_PER_SEC)
@@ -101,7 +109,7 @@ final class SessionManager: SessionManaging {
         }
     }
     
-    func start(sessionId: String = SecureIDGenerator.generateSecureID()) {
+    func start(sessionId: String, isCustomSession: Bool) {
         cancellablesQueue.sync {
             cancellables.removeAll()
             appLifecycleManager
@@ -115,6 +123,7 @@ final class SessionManager: SessionManaging {
         let newSessionInfo = SessionInfo(id: sessionId, startTime: Date())
         stateQueue.sync(flags: .barrier) { [weak self] in
             self?._sessionInfo = newSessionInfo
+            self?._isCustomSession = isCustomSession
             self?.backgroundTime = nil
         }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes session lifecycle semantics by distinguishing custom vs auto-generated session IDs and disabling background-timeout resets for custom sessions, which could affect session attribution and replay/log correlation. Also includes a small dependency bump and API call-site adjustment.
> 
> **Overview**
> Adds a custom-session mode to observability sessions: `ObservabilityService.start(sessionId:)` now starts a session flagged as custom, while the parameterless `start()` creates an auto session ID and flags it as non-custom.
> 
> `SessionManager` tracks `isCustomSession` and skips background-timeout-based session resets for custom sessions, while updating the `SessionManaging` API accordingly (with a compatibility helper). Also updates the example app for the `recordError` call signature change and bumps `ios-client-sdk` to `11.1.1` in `Package.resolved`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2bec153babe492801f8ce77774c3e25c4c182a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->