### PR TITLE
fix: tvOS detect background color

### DIFF
--- a/Sources/LaunchDarklyObservability/UIInteractions/InputCaptureCoordinator.swift
+++ b/Sources/LaunchDarklyObservability/UIInteractions/InputCaptureCoordinator.swift
@@ -22,7 +22,6 @@ struct TouchSample: Sendable {
     let timestamp: TimeInterval
     let target: TouchTarget?
 
-    
     init(touch: UITouch, window: UIWindow, target: TouchTarget?) {
         self.id = ObjectIdentifier(touch)
         self.location = touch.location(in: window)

--- a/Sources/LaunchDarklySessionReplay/ScreenCapture/TileDiffManager.swift
+++ b/Sources/LaunchDarklySessionReplay/ScreenCapture/TileDiffManager.swift
@@ -20,6 +20,7 @@ struct TiledFrame {
         let format = UIGraphicsImageRendererFormat()
         format.scale = scale
         format.opaque = false
+        format.preferredRange = .standard
         let renderer = UIGraphicsImageRenderer(size: originalSize, format: format)
         return renderer.image { _ in
             for capturedImage in tiles {

--- a/Sources/LaunchDarklySessionReplay/ScreenCapture/WindowCaptureManager.swift
+++ b/Sources/LaunchDarklySessionReplay/ScreenCapture/WindowCaptureManager.swift
@@ -6,6 +6,7 @@ final class WindowCaptureManager {
         let format = UIGraphicsImageRendererFormat()
         format.scale = scale
         format.opaque = false
+        format.preferredRange = .standard
         return UIGraphicsImageRenderer(size: size, format: format)
     }
 
@@ -25,12 +26,27 @@ final class WindowCaptureManager {
         }
     }
 
+#if os(tvOS)
+    private static func findFocusedView(in view: UIView) -> UIView? {
+        for subview in view.subviews {
+            if let focused = findFocusedView(in: subview) {
+                return focused
+            }
+        }
+        return view.isFocused ? view : nil
+    }
+#endif
+
     func drawWindows(_ windows: [UIWindow],
                      into context: CGContext,
                      bounds: CGRect,
                      afterScreenUpdates: Bool) {
         context.saveGState()
+#if os(tvOS)
+        context.setFillColor(UIColor.black.cgColor)
+#else
         context.setFillColor(UIColor.clear.cgColor)
+#endif
         context.fill(bounds)
         context.restoreGState()
 
@@ -43,7 +59,50 @@ final class WindowCaptureManager {
             context.translateBy(x: anchor.x, y: anchor.y)
             context.translateBy(x: -anchor.x, y: -anchor.y)
 
+#if os(tvOS)
+            let format = UIGraphicsImageRendererFormat()
+            format.opaque = false
+            format.preferredRange = .standard
+            
+            // 1. layer.render gives perfect unselected rows, but missing focus highlight
+            let layerImage = UIGraphicsImageRenderer(size: window.bounds.size, format: format).image { ctx in
+                window.layer.render(in: ctx.cgContext)
+            }
+            
+            // 2. drawHierarchy gives perfect focused row, but broken unselected rows
+            let hierarchyImage = UIGraphicsImageRenderer(size: window.bounds.size, format: format).image { ctx in
+                window.drawHierarchy(in: window.bounds, afterScreenUpdates: false)
+            }
+            
+            if let focusedView = Self.findFocusedView(in: window) {
+                let focusedLayer = focusedView.layer.presentation() ?? focusedView.layer
+                
+                // Get the exact frame of the focused row on screen
+                let focusedFrame = window.layer.convert(focusedLayer.bounds, from: focusedLayer)
+                // Expand by 40pt to include the scale-up effect, shadow, and glowing focus highlight
+                let cutoutFrame = focusedFrame.insetBy(dx: -40, dy: -40)
+                
+                context.saveGState()
+                
+                // Draw the perfect focused row (and the broken unselected rows)
+                hierarchyImage.draw(in: window.bounds)
+                
+                // Create a clipping mask that has a hole exactly where the focused row is
+                context.beginPath()
+                context.addRect(window.bounds)
+                context.addRect(cutoutFrame)
+                context.clip(using: .evenOdd)
+                
+                // Draw the perfect unselected rows everywhere else (ignoring the hole)
+                layerImage.draw(in: window.bounds)
+                
+                context.restoreGState()
+            } else {
+                layerImage.draw(in: window.bounds)
+            }
+#else
             window.drawHierarchy(in: window.layer.frame, afterScreenUpdates: afterScreenUpdates)
+#endif
 
             context.restoreGState()
         }

--- a/Sources/LaunchDarklySessionReplay/ScreenCapture/WindowCaptureManager.swift
+++ b/Sources/LaunchDarklySessionReplay/ScreenCapture/WindowCaptureManager.swift
@@ -26,17 +26,6 @@ final class WindowCaptureManager {
         }
     }
 
-#if os(tvOS)
-    private static func findFocusedView(in view: UIView) -> UIView? {
-        for subview in view.subviews {
-            if let focused = findFocusedView(in: subview) {
-                return focused
-            }
-        }
-        return view.isFocused ? view : nil
-    }
-#endif
-
     func drawWindows(_ windows: [UIWindow],
                      into context: CGContext,
                      bounds: CGRect,
@@ -59,50 +48,7 @@ final class WindowCaptureManager {
             context.translateBy(x: anchor.x, y: anchor.y)
             context.translateBy(x: -anchor.x, y: -anchor.y)
 
-#if os(tvOS)
-            let format = UIGraphicsImageRendererFormat()
-            format.opaque = false
-            format.preferredRange = .standard
-            
-            // 1. layer.render gives perfect unselected rows, but missing focus highlight
-            let layerImage = UIGraphicsImageRenderer(size: window.bounds.size, format: format).image { ctx in
-                window.layer.render(in: ctx.cgContext)
-            }
-            
-            // 2. drawHierarchy gives perfect focused row, but broken unselected rows
-            let hierarchyImage = UIGraphicsImageRenderer(size: window.bounds.size, format: format).image { ctx in
-                window.drawHierarchy(in: window.bounds, afterScreenUpdates: false)
-            }
-            
-            if let focusedView = Self.findFocusedView(in: window) {
-                let focusedLayer = focusedView.layer.presentation() ?? focusedView.layer
-                
-                // Get the exact frame of the focused row on screen
-                let focusedFrame = window.layer.convert(focusedLayer.bounds, from: focusedLayer)
-                // Expand by 40pt to include the scale-up effect, shadow, and glowing focus highlight
-                let cutoutFrame = focusedFrame.insetBy(dx: -40, dy: -40)
-                
-                context.saveGState()
-                
-                // Draw the perfect focused row (and the broken unselected rows)
-                hierarchyImage.draw(in: window.bounds)
-                
-                // Create a clipping mask that has a hole exactly where the focused row is
-                context.beginPath()
-                context.addRect(window.bounds)
-                context.addRect(cutoutFrame)
-                context.clip(using: .evenOdd)
-                
-                // Draw the perfect unselected rows everywhere else (ignoring the hole)
-                layerImage.draw(in: window.bounds)
-                
-                context.restoreGState()
-            } else {
-                layerImage.draw(in: window.bounds)
-            }
-#else
             window.drawHierarchy(in: window.layer.frame, afterScreenUpdates: afterScreenUpdates)
-#endif
 
             context.restoreGState()
         }

--- a/Sources/LaunchDarklySessionReplay/ScreenCapture/WindowCaptureManager.swift
+++ b/Sources/LaunchDarklySessionReplay/ScreenCapture/WindowCaptureManager.swift
@@ -32,7 +32,8 @@ final class WindowCaptureManager {
                      afterScreenUpdates: Bool) {
         context.saveGState()
 #if os(tvOS)
-        context.setFillColor(UIColor.black.cgColor)
+        let isDarkMode = windows.first?.traitCollection.userInterfaceStyle == .dark
+        context.setFillColor(isDarkMode ? UIColor.black.cgColor : UIColor.white.cgColor)
 #else
         context.setFillColor(UIColor.clear.cgColor)
 #endif

--- a/TestApp/Sources/ExampleAppApp.swift
+++ b/TestApp/Sources/ExampleAppApp.swift
@@ -6,7 +6,11 @@ struct ExampleAppApp: App {
     
     var body: some Scene {
         WindowGroup {
+            #if os(tvOS)
+            TVMainMenuView()
+            #else
             MainMenuView()
+            #endif
         }
     }
 }

--- a/TestApp/Sources/TVFrutaAppView.swift
+++ b/TestApp/Sources/TVFrutaAppView.swift
@@ -1,0 +1,268 @@
+#if os(tvOS)
+
+import SwiftUI
+
+struct TVFrutaAppView: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var selectedItem: FrutaItem?
+
+    private let columns = [GridItem(.adaptive(minimum: 350), spacing: 50)]
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                LazyVGrid(columns: columns, spacing: 50) {
+                    ForEach(FrutaItem.all) { item in
+                        TVFrutaCard(item: item) {
+                            selectedItem = item
+                        }
+                    }
+                }
+                .padding(80)
+            }
+            .navigationTitle("Fruta Gallery")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Close") { dismiss() }
+                }
+            }
+            .fullScreenCover(item: $selectedItem) { item in
+                TVFrutaDetailView(item: item, allItems: FrutaItem.all)
+            }
+        }
+    }
+}
+
+// MARK: - Card
+
+private struct TVFrutaCard: View {
+    let item: FrutaItem
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            VStack(spacing: 0) {
+                item.gradient
+                    .overlay {
+                        Image(systemName: item.systemImage)
+                            .font(.system(size: 80))
+                            .foregroundStyle(.white.opacity(0.9))
+                    }
+                    .frame(height: 250)
+                    .clipped()
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(item.name)
+                        .font(.title3)
+                        .fontWeight(.semibold)
+                    Text(item.subtitle)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(20)
+            }
+        }
+        .buttonStyle(.card)
+    }
+}
+
+// MARK: - Detail
+
+private struct TVFrutaDetailView: View {
+    let item: FrutaItem
+    let allItems: [FrutaItem]
+    @Environment(\.dismiss) private var dismiss
+    @State private var currentIndex: Int = 0
+
+    var body: some View {
+        ZStack {
+            displayedItem.gradient
+                .ignoresSafeArea()
+                .opacity(0.4)
+
+            VStack(spacing: 40) {
+                Spacer()
+
+                displayedItem.gradient
+                    .overlay {
+                        Image(systemName: displayedItem.systemImage)
+                            .font(.system(size: 180))
+                            .foregroundStyle(.white.opacity(0.9))
+                    }
+                    .frame(width: 600, height: 400)
+                    .clipShape(RoundedRectangle(cornerRadius: 24))
+
+                VStack(spacing: 12) {
+                    Text(displayedItem.name)
+                        .font(.largeTitle)
+                        .fontWeight(.bold)
+                    Text(displayedItem.subtitle)
+                        .font(.title3)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                        .frame(maxWidth: 500)
+                }
+
+                HStack(spacing: 32) {
+                    Button {
+                        withAnimation { navigatePrevious() }
+                    } label: {
+                        Label("Previous", systemImage: "chevron.left")
+                    }
+                    .disabled(currentIndex <= 0)
+
+                    Text("\(currentIndex + 1) of \(allItems.count)")
+                        .font(.headline)
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+
+                    Button {
+                        withAnimation { navigateNext() }
+                    } label: {
+                        Label("Next", systemImage: "chevron.right")
+                    }
+                    .disabled(currentIndex >= allItems.count - 1)
+                }
+
+                Spacer()
+
+                Button("Close") { dismiss() }
+                    .buttonStyle(.bordered)
+            }
+            .padding(60)
+        }
+        .onAppear {
+            currentIndex = allItems.firstIndex(where: { $0.id == item.id }) ?? 0
+        }
+    }
+
+    private var displayedItem: FrutaItem {
+        allItems[currentIndex]
+    }
+
+    private func navigatePrevious() {
+        guard currentIndex > 0 else { return }
+        currentIndex -= 1
+    }
+
+    private func navigateNext() {
+        guard currentIndex < allItems.count - 1 else { return }
+        currentIndex += 1
+    }
+}
+
+// MARK: - Data Model
+
+struct FrutaItem: Identifiable, Hashable {
+    let id: String
+    let name: String
+    let subtitle: String
+    let systemImage: String
+    let gradientColors: [Color]
+
+    var gradient: LinearGradient {
+        LinearGradient(
+            colors: gradientColors,
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    }
+
+    func hash(into hasher: inout Hasher) { hasher.combine(id) }
+    static func == (lhs: FrutaItem, rhs: FrutaItem) -> Bool { lhs.id == rhs.id }
+
+    static let all: [FrutaItem] = [
+        FrutaItem(
+            id: "strawberry",
+            name: "Strawberry",
+            subtitle: "Sweet and juicy summer berry",
+            systemImage: "leaf.fill",
+            gradientColors: [.red, .pink]
+        ),
+        FrutaItem(
+            id: "banana",
+            name: "Banana",
+            subtitle: "Creamy tropical classic",
+            systemImage: "moon.fill",
+            gradientColors: [.yellow, .orange]
+        ),
+        FrutaItem(
+            id: "blueberry",
+            name: "Blueberry",
+            subtitle: "Antioxidant-rich superfruit",
+            systemImage: "circle.fill",
+            gradientColors: [.indigo, .blue]
+        ),
+        FrutaItem(
+            id: "mango",
+            name: "Mango",
+            subtitle: "The king of tropical fruits",
+            systemImage: "sun.max.fill",
+            gradientColors: [.orange, .yellow]
+        ),
+        FrutaItem(
+            id: "kiwi",
+            name: "Kiwi",
+            subtitle: "Tangy green delight",
+            systemImage: "circle.hexagongrid.fill",
+            gradientColors: [.green, .mint]
+        ),
+        FrutaItem(
+            id: "watermelon",
+            name: "Watermelon",
+            subtitle: "Refreshing summer staple",
+            systemImage: "drop.fill",
+            gradientColors: [.green, .red]
+        ),
+        FrutaItem(
+            id: "coconut",
+            name: "Coconut",
+            subtitle: "Tropical hydration",
+            systemImage: "circle.circle.fill",
+            gradientColors: [.brown, .white.opacity(0.8)]
+        ),
+        FrutaItem(
+            id: "pineapple",
+            name: "Pineapple",
+            subtitle: "Zesty tropical punch",
+            systemImage: "crown.fill",
+            gradientColors: [.yellow, .green]
+        ),
+        FrutaItem(
+            id: "avocado",
+            name: "Avocado",
+            subtitle: "Creamy and nutritious",
+            systemImage: "oval.fill",
+            gradientColors: [.green, .brown]
+        ),
+        FrutaItem(
+            id: "raspberry",
+            name: "Raspberry",
+            subtitle: "Tart and vibrant berry",
+            systemImage: "heart.fill",
+            gradientColors: [.pink, .purple]
+        ),
+        FrutaItem(
+            id: "lemon",
+            name: "Lemon",
+            subtitle: "Bright citrus zing",
+            systemImage: "sparkle",
+            gradientColors: [.yellow, .green.opacity(0.6)]
+        ),
+        FrutaItem(
+            id: "orange",
+            name: "Orange",
+            subtitle: "Classic citrus burst",
+            systemImage: "sun.min.fill",
+            gradientColors: [.orange, .red.opacity(0.7)]
+        ),
+    ]
+}
+
+#Preview {
+    TVFrutaAppView()
+}
+
+#endif

--- a/TestApp/Sources/TVMainMenuView.swift
+++ b/TestApp/Sources/TVMainMenuView.swift
@@ -1,0 +1,287 @@
+#if os(tvOS)
+
+import SwiftUI
+import LaunchDarklyObservability
+import LaunchDarklySessionReplay
+import LaunchDarkly
+
+struct TVMainMenuView: View {
+    @StateObject private var viewModel = MainMenuViewModel()
+    @State private var isSessionReplayEnabled = true
+    @State private var showFruta = false
+    @State private var showMaskingSimple = false
+    @State private var showNumberPad = false
+
+    var body: some View {
+        TabView {
+            sessionReplayTab
+                .tabItem { Label("Session Replay", systemImage: "rectangle.on.rectangle") }
+            instrumentationTab
+                .tabItem { Label("Instrumentation", systemImage: "waveform.path.ecg") }
+            metricsTab
+                .tabItem { Label("Metrics", systemImage: "chart.bar.fill") }
+            customerAPITab
+                .tabItem { Label("Customer API", systemImage: "terminal.fill") }
+        }
+        .fullScreenCover(isPresented: $showFruta) {
+            TVFrutaAppView()
+        }
+        .fullScreenCover(isPresented: $showMaskingSimple) {
+            TVDismissableWrapper {
+                MaskingElementsSimpleUIKitView()
+            }
+        }
+        .fullScreenCover(isPresented: $showNumberPad) {
+            TVDismissableWrapper {
+                NumberPadView()
+            }
+        }
+    }
+
+    // MARK: - Session Replay
+
+    private var sessionReplayTab: some View {
+        ScrollView {
+            VStack(spacing: 48) {
+                headerView
+
+                HStack(spacing: 24) {
+                    Toggle(isOn: $isSessionReplayEnabled) {
+                        Label("Session Replay", systemImage: "record.circle")
+                    }
+                    .onChange(of: isSessionReplayEnabled) { enabled in
+                        if enabled {
+                            LDReplay.shared.start()
+                        } else {
+                            LDReplay.shared.stop()
+                        }
+                    }
+                }
+                .padding(.horizontal, 80)
+
+                LazyVGrid(columns: [GridItem(.adaptive(minimum: 300), spacing: 40)], spacing: 40) {
+                    TVCardButton(title: "One TextField", subtitle: "UIKit masking test", systemImage: "textformat") {
+                        showMaskingSimple = true
+                    }
+                    TVCardButton(title: "Number Pad", subtitle: "SwiftUI number grid", systemImage: "number.square") {
+                        showNumberPad = true
+                    }
+                    TVCardButton(title: "Fruta Gallery", subtitle: "Ingredients & smoothies", systemImage: "leaf.fill") {
+                        showFruta = true
+                    }
+                }
+                .padding(.horizontal, 80)
+            }
+            .padding(.vertical, 60)
+        }
+    }
+
+    // MARK: - Instrumentation
+
+    private var instrumentationTab: some View {
+        ScrollView {
+            VStack(spacing: 48) {
+                headerView
+
+                VStack(alignment: .leading, spacing: 32) {
+                    Text("Identify")
+                        .font(.title2)
+                        .foregroundStyle(.secondary)
+
+                    HStack(spacing: 24) {
+                        TVActionButton(title: "User", tint: Colors.identifyBgColor) {
+                            viewModel.identifyUser()
+                        }
+                        TVActionButton(title: "Multi", tint: Colors.identifyBgColor) {
+                            viewModel.identifyMulti()
+                        }
+                        TVActionButton(title: "Anonymous", tint: Colors.identifyBgColor) {
+                            viewModel.identifyAnonymous()
+                        }
+                    }
+                }
+                .padding(.horizontal, 80)
+
+                VStack(alignment: .leading, spacing: 32) {
+                    Text("Network & Crash")
+                        .font(.title2)
+                        .foregroundStyle(.secondary)
+
+                    HStack(spacing: 24) {
+                        TVActionButton(title: viewModel.isNetworkInProgress ? "Requesting…" : "Network Request", tint: .blue) {
+                            Task { await viewModel.performNetworkRequest() }
+                        }
+                        TVActionButton(title: "Crash", tint: .red) {
+                            viewModel.crash()
+                        }
+                    }
+                }
+                .padding(.horizontal, 80)
+            }
+            .padding(.vertical, 60)
+        }
+    }
+
+    // MARK: - Metrics
+
+    private var metricsTab: some View {
+        ScrollView {
+            VStack(spacing: 48) {
+                headerView
+
+                LazyVGrid(columns: [GridItem(.adaptive(minimum: 280), spacing: 40)], spacing: 40) {
+                    TVCardButton(title: "Gauge", subtitle: "Record metric", systemImage: "gauge.medium") {
+                        viewModel.recordMetric()
+                    }
+                    TVCardButton(title: "Histogram", subtitle: "Record histogram", systemImage: "chart.bar.xaxis") {
+                        viewModel.recordHistogramMetric()
+                    }
+                    TVCardButton(title: "Counter", subtitle: "Record count", systemImage: "number") {
+                        viewModel.recordCounterMetric()
+                    }
+                    TVCardButton(title: "Incremental", subtitle: "Increment counter", systemImage: "plus.circle") {
+                        viewModel.recordIncrementalMetric()
+                    }
+                    TVCardButton(title: "Up/Down", subtitle: "Up-down counter", systemImage: "arrow.up.arrow.down") {
+                        viewModel.recordUpDownCounterMetric()
+                    }
+                }
+                .padding(.horizontal, 80)
+            }
+            .padding(.vertical, 60)
+        }
+    }
+
+    // MARK: - Customer API
+
+    private var customerAPITab: some View {
+        ScrollView {
+            VStack(spacing: 48) {
+                headerView
+
+                VStack(alignment: .leading, spacing: 32) {
+                    Text("Errors & Logs")
+                        .font(.title2)
+                        .foregroundStyle(.secondary)
+
+                    HStack(spacing: 24) {
+                        TVActionButton(title: "Error", tint: .red) {
+                            viewModel.recordError()
+                        }
+                        TVActionButton(title: "Log", tint: .blue) {
+                            viewModel.recordLogs()
+                        }
+                        TVActionButton(title: "Log with Context", tint: .indigo) {
+                            viewModel.recordLogWithContext()
+                        }
+                    }
+                }
+                .padding(.horizontal, 80)
+
+                VStack(alignment: .leading, spacing: 32) {
+                    Text("Spans")
+                        .font(.title2)
+                        .foregroundStyle(.secondary)
+
+                    HStack(spacing: 24) {
+                        TVActionButton(title: "Span & Flag Eval", tint: .green) {
+                            viewModel.recordSpanAndVariation()
+                        }
+                        TVActionButton(title: "Nested Spans", tint: .teal) {
+                            viewModel.triggerNestedSpans()
+                        }
+                    }
+                }
+                .padding(.horizontal, 80)
+            }
+            .padding(.vertical, 60)
+        }
+    }
+
+    // MARK: - Header
+
+    private var headerView: some View {
+        HStack(spacing: 16) {
+            Image("Logo")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(height: 60)
+            Text("LaunchDarkly Observability")
+                .font(.title)
+                .fontWeight(.semibold)
+            Text(Date().formatted(.dateTime.hour().minute().second()))
+                .font(.title3)
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+// MARK: - tvOS Card Button
+
+private struct TVCardButton: View {
+    let title: String
+    let subtitle: String
+    let systemImage: String
+    let action: () -> Void
+
+    @Environment(\.isFocused) private var isFocused
+
+    var body: some View {
+        Button(action: action) {
+            VStack(spacing: 16) {
+                Image(systemName: systemImage)
+                    .font(.system(size: 48))
+                    .foregroundStyle(.tint)
+                Text(title)
+                    .font(.headline)
+                Text(subtitle)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(32)
+        }
+        .buttonStyle(.card)
+    }
+}
+
+// MARK: - tvOS Action Button
+
+private struct TVActionButton: View {
+    let title: String
+    let tint: Color
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .fontWeight(.semibold)
+        }
+        .tint(tint)
+        .buttonStyle(.borderedProminent)
+    }
+}
+
+// MARK: - Dismissable Wrapper
+
+private struct TVDismissableWrapper<Content: View>: View {
+    @Environment(\.dismiss) private var dismiss
+    let content: () -> Content
+
+    var body: some View {
+        NavigationStack {
+            content()
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Close") { dismiss() }
+                    }
+                }
+        }
+    }
+}
+
+#Preview {
+    TVMainMenuView()
+}
+
+#endif


### PR DESCRIPTION
- detect background color
- tvOS idiomatic test app

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts session-replay rendering behavior (renderer color range and tvOS background fill), which can affect capture output quality across devices/OS versions. Also adds substantial tvOS-only test-app UI, but it is isolated to the example target.
> 
> **Overview**
> Improves session replay screenshot rendering by forcing `UIGraphicsImageRendererFormat.preferredRange = .standard` when composing tiles and when capturing windows, to avoid wide-gamut/HDR-related color differences.
> 
> On tvOS, window capture now clears the frame using an inferred light/dark background color (white/black) instead of transparent, reducing incorrect background artifacts.
> 
> Updates the example app to use a new tvOS-specific main menu (`TVMainMenuView`) and adds a tvOS Fruta gallery flow (`TVFrutaAppView`) for exercising session replay, masking, and instrumentation scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6cb3c1b56f904a67be2d4e5b847d0cec6c070b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->