### PR TITLE
docs: Readme Masking rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,21 @@ class CreditCardViewController: UIViewController {
 }
 ```
 
+#### How the SDK Determines What to Mask
+
+When deciding whether a specific view should be masked in a Session Replay, the SDK evaluates rules in a strict order of precedence. It checks these conditions from top to bottom and stops at the first one that applies:
+
+1. **Explicit Masking (Highest Priority)**: Is the view, or *any* of its parent views, explicitly masked (e.g., using `.ldMask()`)?
+   * **Yes**: The view is **masked**. This overrides all other rules.
+2. **Explicit Unmasking**: Is the view itself explicitly unmasked (e.g., using `.ldUnmask()`)?
+   * **Yes**: The view is **unmasked**.
+3. **Inherited Unmasking**: Does the nearest parent view with an explicit rule have an unmask rule?
+   * **Yes**: The view is **unmasked**.
+4. **Global Configuration**: Does your global privacy configuration (like `maskTextInputs`, `maskImages`, etc.) apply to this view?
+   * **Yes**: The view follows the global configuration.
+
+*Note: If multiple rules conflict at the same level, masking wins over unmasking.*
+
 ### Advanced Configuration
 
 You can customize the observability plugin with various options:

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ class CreditCardViewController: UIViewController {
 
 When deciding whether a specific view should be masked in a Session Replay, the SDK evaluates rules in a strict order of precedence. It checks these conditions from top to bottom and stops at the first one that applies:
 
-1. **Explicit Masking (Highest Priority)**: Is the view, or *any* of its parent views, explicitly masked (e.g., using `.ldMask()`)?
+1. **Explicit Masking (Highest Priority)**: Is the view, or *any* of its parent views, explicitly masked (e.g., using `.ldMask()` or matching `maskAccessibilityIdentifiers`)?
    * **Yes**: The view is **masked**. This overrides all other rules.
 2. **Explicit Unmasking**: Is the view itself explicitly unmasked (e.g., using `.ldUnmask()`)?
    * **Yes**: The view is **unmasked**.


### PR DESCRIPTION
## Summary
This PR updates the `README.md` to clarify the precedence rules the SDK uses to determine whether a view should be masked during Session Replay. 

Previously, the masking logic was not explicitly documented, which could make it difficult for customer engineers and users to understand how conflicting rules are resolved.

## Changes
* Added a new **"How the SDK Determines What to Mask"** section under the Fine-grained Masking Control documentation.
* Documented the strict 4-step order of precedence for masking rules:
  1. Explicit Masking (Highest Priority)
  2. Explicit Unmasking
  3. Inherited Unmasking
  4. Global Configuration
* Added a clarifying note that if multiple rules conflict at the same level, masking wins over unmasking.

## Test plan
* Reviewed the rendered Markdown locally to ensure proper formatting and readability.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, API, or behavioral impact.
> 
> **Overview**
> Updates `README.md` with a new **"How the SDK Determines What to Mask"** section that explicitly documents the order of precedence the Session Replay SDK uses when masking views (explicit mask, explicit unmask, inherited unmask, then global privacy settings), including a note that masking wins on same-level conflicts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3722ca7c827aa8db10f701fe0210ea584573dbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->