### PR TITLE
feat: Adds new Session Replay capture settings frameRate and renderStrategy

### DIFF
--- a/Sources/LaunchDarklySessionReplay/API/SessionReplayOptions.swift
+++ b/Sources/LaunchDarklySessionReplay/API/SessionReplayOptions.swift
@@ -49,11 +49,19 @@ public struct SessionReplayOptions {
         case overlayTiles(layers: Int = 10, backtracking: Bool = true)
     }
     
+    public enum RenderStrategy {
+        case drawHierarchy
+        case drawLayers
+    }
+    
     public var isEnabled: Bool
     /// Probability from `0.0` to `1.0` that Session Replay starts when enabled.
     /// Values less than or equal to zero never start; values greater than or equal to one always start.
     public var sampleRate: Double
     public var compression: CompressionMethod = .overlayTiles()
+    /// Target capture rate in frames per second.
+    public var frameRate: Double
+    public var renderStrategy: RenderStrategy
     public var serviceName: String
     public var privacy = PrivacyOptions()
     public var log: OSLog
@@ -63,12 +71,16 @@ public struct SessionReplayOptions {
                 serviceName: String = "sessionreplay-swift",
                 privacy: PrivacyOptions = PrivacyOptions(),
                 compression: CompressionMethod = .overlayTiles(),
+                frameRate: Double = 1.0,
+                renderStrategy: RenderStrategy = .drawHierarchy,
                 log: OSLog = OSLog(subsystem: "com.launchdarkly", category: "LaunchDarklySessionReplayPlugin")) {
         self.isEnabled = isEnabled
         self.sampleRate = sampleRate
         self.serviceName = serviceName
         self.privacy = privacy
         self.compression = compression
+        self.frameRate = frameRate
+        self.renderStrategy = renderStrategy
         self.log = log
     }
 }

--- a/Sources/LaunchDarklySessionReplay/ScreenCapture/CaptureManager.swift
+++ b/Sources/LaunchDarklySessionReplay/ScreenCapture/CaptureManager.swift
@@ -12,7 +12,7 @@ final class CaptureManager: EventSource {
     private let eventQueue: EventQueue
     @MainActor
     private var lastFrameDispatchTime: DispatchTime?
-    private let frameInterval = 1.0
+    private let frameInterval: Double
     @MainActor
     private var isEventQueueAvailable: Bool = true
     private let sessionExporterId = ObjectIdentifier(SessionReplayExporter.self)
@@ -35,10 +35,12 @@ final class CaptureManager: EventSource {
     
     init(captureService: ImageCaptureServicing,
          compression: SessionReplayOptions.CompressionMethod,
+         frameRate: Double,
          appLifecycleManager: AppLifecycleManaging,
          eventQueue: EventQueue,
          sessionIdProvider: @Sendable @escaping () -> String) {
         self.captureService = captureService
+        self.frameInterval = frameRate > 0 ? 1.0 / frameRate : .infinity
         self.exportDiffManager = ExportDiffManager(compression: compression, scale: 1.0)
         self.eventQueue = eventQueue
         self.appLifecycleManager = appLifecycleManager

--- a/Sources/LaunchDarklySessionReplay/ScreenCapture/CaptureManager.swift
+++ b/Sources/LaunchDarklySessionReplay/ScreenCapture/CaptureManager.swift
@@ -4,7 +4,7 @@ import LaunchDarklyObservability
 import UIKit
 
 final class CaptureManager: EventSource {
-    private let captureService: ImageCaptureService
+    private let captureService: ImageCaptureServicing
     private let exportDiffManager: ExportDiffManager
     private let appLifecycleManager: AppLifecycleManaging
     @MainActor
@@ -33,7 +33,7 @@ final class CaptureManager: EventSource {
         }
     }
     
-    init(captureService: ImageCaptureService,
+    init(captureService: ImageCaptureServicing,
          compression: SessionReplayOptions.CompressionMethod,
          appLifecycleManager: AppLifecycleManaging,
          eventQueue: EventQueue,

--- a/Sources/LaunchDarklySessionReplay/ScreenCapture/ImageCaptureService.swift
+++ b/Sources/LaunchDarklySessionReplay/ScreenCapture/ImageCaptureService.swift
@@ -31,6 +31,7 @@ public final class ImageCaptureService: ImageCaptureServicing {
     private let maskCollector: MaskCollector
     private let maskStabilizer = MaskStabilizer()
     private let windowCaptureManager = WindowCaptureManager()
+    private let renderStrategy: SessionReplayOptions.RenderStrategy
     @MainActor
     private var shouldCapture = false
     
@@ -38,6 +39,7 @@ public final class ImageCaptureService: ImageCaptureServicing {
     
     public init(options: SessionReplayOptions) {
         maskCollector = MaskCollector(privacySettings: options.privacy)
+        renderStrategy = options.renderStrategy
     }
     
     // MARK: - Capture
@@ -64,7 +66,7 @@ public final class ImageCaptureService: ImageCaptureServicing {
         
         let maskOperationsBefore = windows.map { maskCollector.collectViewMasks(in: $0, window: $0, scale: scale)  }
         let image = renderer.image { ctx in
-            windowCaptureManager.drawWindows(windows, into: ctx.cgContext, bounds: enclosingBounds, afterScreenUpdates: false)
+            windowCaptureManager.drawWindows(windows, into: ctx.cgContext, bounds: enclosingBounds, afterScreenUpdates: false, renderStrategy: renderStrategy)
         }
       
         shouldCapture = true // can be set to false from external class to stop capturing work early
@@ -114,6 +116,7 @@ public final class ImageCaptureService: ImageCaptureServicing {
     }
 }
 
+#if DEBUG
 // MARK: - Thread CPU Time
 private extension ImageCaptureService {
     /// Measure CPU and wall-clock time for work executed on the current thread.
@@ -149,5 +152,6 @@ private extension ImageCaptureService {
         return seconds + (microseconds / 1_000_000)
     }
 }
+#endif
 
 #endif

--- a/Sources/LaunchDarklySessionReplay/ScreenCapture/ImageCaptureService.swift
+++ b/Sources/LaunchDarklySessionReplay/ScreenCapture/ImageCaptureService.swift
@@ -18,7 +18,15 @@ public struct RawFrame {
     }
 }
 
-public final class ImageCaptureService {
+public protocol ImageCaptureServicing: AnyObject {
+    @MainActor
+    func captureRawFrame(yield: @escaping (RawFrame?) async -> Void)
+
+    @MainActor
+    func interuptCapture()
+}
+
+public final class ImageCaptureService: ImageCaptureServicing {
     private let maskingService = MaskApplier()
     private let maskCollector: MaskCollector
     private let maskStabilizer = MaskStabilizer()
@@ -43,7 +51,7 @@ public final class ImageCaptureService {
     
     /// Capture as masked frame (must be on main thread).
     @MainActor
-    func captureRawFrame(yield: @escaping (RawFrame?) async -> Void) {
+    public func captureRawFrame(yield: @escaping (RawFrame?) async -> Void) {
 #if os(iOS)
         let orientation = UIDevice.current.orientation.isLandscape ? 1 : 0
 #else
@@ -101,7 +109,7 @@ public final class ImageCaptureService {
     }
 
     @MainActor
-    func interuptCapture() {
+    public func interuptCapture() {
         shouldCapture = false
     }
 }

--- a/Sources/LaunchDarklySessionReplay/ScreenCapture/WindowCaptureManager.swift
+++ b/Sources/LaunchDarklySessionReplay/ScreenCapture/WindowCaptureManager.swift
@@ -29,7 +29,8 @@ final class WindowCaptureManager {
     func drawWindows(_ windows: [UIWindow],
                      into context: CGContext,
                      bounds: CGRect,
-                     afterScreenUpdates: Bool) {
+                     afterScreenUpdates: Bool,
+                     renderStrategy: SessionReplayOptions.RenderStrategy) {
         context.saveGState()
 #if os(tvOS)
         let isDarkMode = windows.first?.traitCollection.userInterfaceStyle == .dark
@@ -49,7 +50,12 @@ final class WindowCaptureManager {
             context.translateBy(x: anchor.x, y: anchor.y)
             context.translateBy(x: -anchor.x, y: -anchor.y)
 
-            window.drawHierarchy(in: window.layer.frame, afterScreenUpdates: afterScreenUpdates)
+            switch renderStrategy {
+            case .drawHierarchy:
+                window.drawHierarchy(in: window.layer.frame, afterScreenUpdates: afterScreenUpdates)
+            case .drawLayers:
+                window.layer.render(in: context)
+            }
 
             context.restoreGState()
         }

--- a/Sources/LaunchDarklySessionReplay/SessionReplay.swift
+++ b/Sources/LaunchDarklySessionReplay/SessionReplay.swift
@@ -9,11 +9,16 @@ import OSLog
 public final class SessionReplay: Plugin {
     let sessionReplayHook = SessionReplayHook()
     let options: SessionReplayOptions
+    let imageCaptureService: ImageCaptureServicing?
     var sessionReplayService: SessionReplayService?
     var observabilityContext: ObservabilityContext?
     
-    public init(options: SessionReplayOptions) {
+    public init(
+        options: SessionReplayOptions,
+        imageCaptureService: ImageCaptureServicing? = nil
+    ) {
         self.options = options
+        self.imageCaptureService = imageCaptureService
     }
     
     public func getMetadata() -> LaunchDarkly.PluginMetadata {
@@ -33,9 +38,12 @@ public final class SessionReplay: Plugin {
                 throw PluginError.sessionReplayInstanceAlreadyExist
             }
            
-            let sessionReplayService = try SessionReplayService(observabilityContext: context,
-                                                                sessonReplayOptions: options,
-                                                                metadata: metadata)
+            let sessionReplayService = try SessionReplayService(
+                observabilityContext: context,
+                sessonReplayOptions: options,
+                metadata: metadata,
+                imageCaptureService: imageCaptureService
+            )
             LDReplay.shared.client = sessionReplayService
             self.sessionReplayService = sessionReplayService
             sessionReplayHook.delegate = sessionReplayService

--- a/Sources/LaunchDarklySessionReplay/SessionReplayService.swift
+++ b/Sources/LaunchDarklySessionReplay/SessionReplayService.swift
@@ -90,7 +90,8 @@ final class SessionReplayService: SessionReplayServicing {
     
     init(observabilityContext: ObservabilityContext,
          sessonReplayOptions: SessionReplayOptions,
-         metadata: LaunchDarkly.EnvironmentMetadata) throws {
+         metadata: LaunchDarkly.EnvironmentMetadata,
+         imageCaptureService: ImageCaptureServicing? = nil) throws {
         guard let url = URL(string: observabilityContext.options.backendUrl) else {
             throw InstrumentationError.invalidGraphQLUrl
         }
@@ -98,10 +99,12 @@ final class SessionReplayService: SessionReplayServicing {
         self.log = observabilityContext.options.log
         self.sampleRate = sessonReplayOptions.sampleRate
         let graphQLClient = GraphQLClient(endpoint: url, defaultHeaders: ["User-Agent": ObservabilitySDKInfo.userAgent()])
-        let captureService = ImageCaptureService(options: sessonReplayOptions)
+        let captureService = imageCaptureService
+            ?? ImageCaptureService(options: sessonReplayOptions)
         self.transportService = observabilityContext.transportService
         self.captureManager = CaptureManager(captureService: captureService,
                                              compression: sessonReplayOptions.compression,
+                                             frameRate: sessonReplayOptions.frameRate,
                                              appLifecycleManager: observabilityContext.appLifecycleManager,
                                              eventQueue: transportService.eventQueue,
                                              sessionIdProvider: observabilityContext.sessionManager.sessionIdProvider)

--- a/Tests/SessionReplayTests/SessionReplayOptionsTests.swift
+++ b/Tests/SessionReplayTests/SessionReplayOptionsTests.swift
@@ -1,0 +1,21 @@
+import Testing
+@testable import LaunchDarklySessionReplay
+
+struct SessionReplayOptionsTests {
+    @Test("frameRate defaults to one frame per second")
+    func frameRateDefaultsToOne() {
+        #expect(SessionReplayOptions().frameRate == 1.0)
+    }
+
+    @Test("renderStrategy defaults to drawHierarchy")
+    func renderStrategyDefaultsToDrawHierarchy() {
+        #expect(SessionReplayOptions().renderStrategy == .drawHierarchy)
+    }
+
+    @Test("frameRate and renderStrategy can be configured")
+    func frameRateAndRenderStrategyAreConfigurable() {
+        let options = SessionReplayOptions(frameRate: 2.0, renderStrategy: .drawLayers)
+        #expect(options.frameRate == 2.0)
+        #expect(options.renderStrategy == .drawLayers)
+    }
+}

--- a/Tests/SessionReplayTests/SessionReplaySamplingTests.swift
+++ b/Tests/SessionReplayTests/SessionReplaySamplingTests.swift
@@ -33,13 +33,15 @@ struct SessionReplaySamplingTests {
         #expect(session.shouldStartCapture(ignoreSampling: false, sampleRate: 0.25, randomValue: { 0.99 }) == false)
         #expect(session.shouldStartCapture(ignoreSampling: false, sampleRate: 0.25, randomValue: { 0.0 }) == false)
         session.reset()
-        #expect(session.shouldStartCapture(ignoreSampling: false, sampleRate: 0.25, randomValue: { 0.0 }))
+        let startedAfterReset = session.shouldStartCapture(ignoreSampling: false, sampleRate: 0.25, randomValue: { 0.0 })
+        #expect(startedAfterReset)
     }
 
     @Test("ignoreSampling bypasses persisted sampled-out decision")
     func ignoreSamplingBypassesPersistedDecision() {
         var session = SessionReplaySamplingSession()
         #expect(session.shouldStartCapture(ignoreSampling: false, sampleRate: 0.25, randomValue: { 0.99 }) == false)
-        #expect(session.shouldStartCapture(ignoreSampling: true, sampleRate: 0.25, randomValue: { 0.99 }))
+        let startedIgnoringSampling = session.shouldStartCapture(ignoreSampling: true, sampleRate: 0.25, randomValue: { 0.99 })
+        #expect(startedIgnoringSampling)
     }
 }


### PR DESCRIPTION
## Summary

Adds new Session Replay capture settings for Swift:

- `frameRate` controls the target capture rate in frames per second.
- `renderStrategy` controls how windows are rendered during screen capture:
  - `.drawHierarchy`
  - `.drawLayers`

Defaults preserve existing behavior: `frameRate` is `1.0` and `renderStrategy` is `.drawHierarchy`.

## Implementation

- Added `SessionReplayOptions.RenderStrategy`.
- Added `frameRate` and `renderStrategy` to `SessionReplayOptions`.
- Threaded `frameRate` into `CaptureManager` and use it to derive the frame interval.
- Threaded `renderStrategy` through `ImageCaptureService` into `WindowCaptureManager`.
- Updated window drawing to switch between `window.drawHierarchy(...)` and `window.layer.render(in:)`.

## Testing

- Added `SessionReplayOptionsTests` for default and configurable values.
- Ran focused Session Replay options tests successfully via:

```sh
./test.sh --test-file Tests/SessionReplayTests/SessionReplayOptionsTests.swift

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes screen capture timing and rendering path (hierarchy vs layer), which can affect replay fidelity, performance, and privacy masking behavior; defaults preserve prior behavior.
> 
> **Overview**
> Adds configurable **Session Replay** capture tuning: **`frameRate`** (FPS target) and **`renderStrategy`** (`.drawHierarchy` vs `.drawLayers` for window rendering).
> 
> **`SessionReplayOptions`** gains `RenderStrategy`, `frameRate` (default **1.0**), and `renderStrategy` (default **`.drawHierarchy`**). **`CaptureManager`** derives its throttle interval from `frameRate` instead of a fixed 1s. **`WindowCaptureManager`** chooses `drawHierarchy` or `layer.render(in:)` per strategy.
> 
> **`ImageCaptureServicing`** protocol plus optional injectable capture service on **`SessionReplay`** / **`SessionReplayService`** (defaults to **`ImageCaptureService`**). Debug-only CPU timing helpers are wrapped in `#if DEBUG`.
> 
> Tests cover option defaults/config and minor sampling test clarity fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c620b6e0665a26cda6c7b6659cc863ba60f42042. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->