### PR TITLE
feat: emit Track custom events in session replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,11 +397,9 @@ span.end()
 // Record a custom track event as a `track` span.
 // (Calling LDClient.get()?.track(key:) records the same span automatically via the afterTrack hook.)
 LDObserve.shared.track(
-    name: "checkout_completed",
-    value: 42.0,
-    attributes: [
-        "currency": .string("USD")
-    ]
+    key: "checkout_completed",
+    data: ["currency": "USD"],
+    metricValue: 42.0
 )
 ```
 

--- a/Sources/LaunchDarklyObservability/API/LDObserve.swift
+++ b/Sources/LaunchDarklyObservability/API/LDObserve.swift
@@ -68,7 +68,7 @@ extension LDObserve: Observe {
         client.startSpan(name: name, attributes: attributes)
     }
 
-    public func track(key: String, data: LDValue?, metricValue: Double?) {
+    public func track(key: String, data: LDValue? = nil, metricValue: Double? = nil) {
         client.track(key: key, data: data, metricValue: metricValue)
     }
 }

--- a/Sources/LaunchDarklyObservability/API/LDObserve.swift
+++ b/Sources/LaunchDarklyObservability/API/LDObserve.swift
@@ -1,4 +1,5 @@
 import Foundation
+import LaunchDarkly
 
 public final class LDObserve  {
     private let clientQueue = DispatchQueue(label: "com.launchdarkly.LDObserve.client")
@@ -67,7 +68,7 @@ extension LDObserve: Observe {
         client.startSpan(name: name, attributes: attributes)
     }
 
-    public func track(name: String, value: Double?, attributes: [String : AttributeValue]) {
-        client.track(name: name, value: value, attributes: attributes)
+    public func track(key: String, data: LDValue?, metricValue: Double?) {
+        client.track(key: key, data: data, metricValue: metricValue)
     }
 }

--- a/Sources/LaunchDarklyObservability/API/ObservabilityOptions.swift
+++ b/Sources/LaunchDarklyObservability/API/ObservabilityOptions.swift
@@ -178,7 +178,7 @@ public struct ObservabilityOptions {
         /// is unaffected by this flag.
         let taps: FeatureFlag
         /// Whether to emit a `track` span when a custom event is tracked
-        /// (via the LD `afterTrack` hook or ``LDObserve/track(name:value:attributes:)``).
+        /// (via the LD `afterTrack` hook or ``LDObserve/track(key:data:metricValue:)``).
         let trackEvents: FeatureFlag
         
         public static var enabled: Self {

--- a/Sources/LaunchDarklyObservability/API/Observe.swift
+++ b/Sources/LaunchDarklyObservability/API/Observe.swift
@@ -19,20 +19,6 @@ public protocol Observe: AnyObject, MetricsApi, LogsApi, TracesApi, ObserveConte
     func track(key: String, data: LDValue?, metricValue: Double?)
 }
 
-extension Observe {
-    public func track(key: String) {
-        track(key: key, data: nil, metricValue: nil)
-    }
-
-    public func track(key: String, data: LDValue?) {
-        track(key: key, data: data, metricValue: nil)
-    }
-
-    public func track(key: String, metricValue: Double?) {
-        track(key: key, data: nil, metricValue: metricValue)
-    }
-}
-
 /// Context for transfer data from Observability to SessionReplay during initialization
 public protocol ObserveContext {
     var context: ObservabilityContext? { get }

--- a/Sources/LaunchDarklyObservability/API/Observe.swift
+++ b/Sources/LaunchDarklyObservability/API/Observe.swift
@@ -1,4 +1,5 @@
 @_exported import OpenTelemetryApi
+import LaunchDarkly
 
 /// Interface for observability operations in the LaunchDarkly iOS SDK.
 /// Provides methods for recording various types of information.
@@ -6,24 +7,29 @@ public protocol Observe: AnyObject, MetricsApi, LogsApi, TracesApi, ObserveConte
     func start(sessionId: String)
     func start()
     /// Record a custom track event as a `track` span.
+    ///
+    /// Mirrors `LDClient.track(key:data:metricValue:)` so the same call shape
+    /// works whether the event is recorded through the LaunchDarkly client (via
+    /// the `afterTrack` hook) or directly through this API.
     /// - Parameters:
-    ///   - name: The event key/name.
-    ///   - value: An optional metric value associated with the event.
-    ///   - attributes: Additional attributes to record with the event.
-    func track(name: String, value: Double?, attributes: [String: AttributeValue])
+    ///   - key: The key for the event.
+    ///   - data: The data associated with the event, if any.
+    ///   - metricValue: A numeric value used by LaunchDarkly experimentation for
+    ///     numeric custom metrics, if any.
+    func track(key: String, data: LDValue?, metricValue: Double?)
 }
 
 extension Observe {
-    public func track(name: String) {
-        track(name: name, value: nil, attributes: [:])
+    public func track(key: String) {
+        track(key: key, data: nil, metricValue: nil)
     }
 
-    public func track(name: String, value: Double?) {
-        track(name: name, value: value, attributes: [:])
+    public func track(key: String, data: LDValue?) {
+        track(key: key, data: data, metricValue: nil)
     }
 
-    public func track(name: String, attributes: [String: AttributeValue]) {
-        track(name: name, value: nil, attributes: attributes)
+    public func track(key: String, metricValue: Double?) {
+        track(key: key, data: nil, metricValue: metricValue)
     }
 }
 

--- a/Sources/LaunchDarklyObservability/Bridge/AttributeConverter.swift
+++ b/Sources/LaunchDarklyObservability/Bridge/AttributeConverter.swift
@@ -8,11 +8,11 @@ import OpenTelemetryApi
 /// `AttributeValue.init?(Any)` does not handle Foundation collection types,
 /// so this converter checks for `NSDictionary` / `NSArray` explicitly and
 /// recurses into nested structures.
-enum AttributeConverter {
+public enum AttributeConverter {
 
     /// Converts a `[String: Any]` dictionary of Foundation values into
     /// `[String: AttributeValue]`.
-    static func convert(_ source: [String: Any]) -> [String: AttributeValue] {
+    public static func convert(_ source: [String: Any]) -> [String: AttributeValue] {
         var result: [String: AttributeValue] = [:]
         for (key, value) in source {
             result[key] = convertValue(value)
@@ -29,7 +29,7 @@ enum AttributeConverter {
     ///    (avoids Swift's special bridging that converts NSNumber(0/1) to Bool)
     /// 4. `String`        → `.string`
     /// 5. Fallback        → `.string(String(describing: value))`
-    static func convertValue(_ value: Any) -> AttributeValue {
+    public static func convertValue(_ value: Any) -> AttributeValue {
         if let nsDict = value as? NSDictionary {
             var labels: [String: AttributeValue] = [:]
             for (key, val) in nsDict {

--- a/Sources/LaunchDarklyObservability/Client/NoOpObservabilityService.swift
+++ b/Sources/LaunchDarklyObservability/Client/NoOpObservabilityService.swift
@@ -1,3 +1,5 @@
+import LaunchDarkly
+
 // Lightweight no-op implementation of Observe used as the default before the Observability plugin is installed.
 /// Does not allocate exporters, start tasks, or perform network requests.
 final class NoOpObservabilityService: Observe {
@@ -20,7 +22,7 @@ final class NoOpObservabilityService: Observe {
         NoOpTracer().startSpan(name: name, attributes: attributes)
     }
 
-    func track(name: String, value: Double?, attributes: [String: AttributeValue]) {}
+    func track(key: String, data: LDValue?, metricValue: Double?) {}
 }
 
 extension NoOpObservabilityService {

--- a/Sources/LaunchDarklyObservability/Client/ObservabilityService.swift
+++ b/Sources/LaunchDarklyObservability/Client/ObservabilityService.swift
@@ -1,6 +1,7 @@
 import Foundation
 import OpenTelemetrySdk
 import OSLog
+import LaunchDarkly
 #if !LD_COCOAPODS
     import Common
 #endif
@@ -382,8 +383,11 @@ extension ObservabilityService: Observe {
         tracer.startSpan(name: name, attributes: attributes)
     }
 
-    func track(name: String, value: Double?, attributes: [String: AttributeValue]) {
-        track(name: name, value: value, attributes: attributes, contextKeyAttributes: nil)
+    func track(key: String, data: LDValue?, metricValue: Double?) {
+        track(name: key,
+              metricValue: metricValue,
+              attributes: data?.toAttributes() ?? [:],
+              contextKeyAttributes: nil)
     }
 }
 
@@ -392,7 +396,7 @@ extension ObservabilityService: TrackEmitting {
     /// manual `LDObserve.track` path funnel through here.
     func track(
         name: String,
-        value: Double?,
+        metricValue: Double?,
         attributes: [String: AttributeValue],
         contextKeyAttributes: [String: AttributeValue]?
     ) {
@@ -409,8 +413,8 @@ extension ObservabilityService: TrackEmitting {
             spanAttributes[k] = v
         }
         spanAttributes["key"] = .string(name)
-        if let value {
-            spanAttributes["value"] = .double(value)
+        if let metricValue {
+            spanAttributes["value"] = .double(metricValue)
         }
 
         let span = tracer.startSpan(name: SemanticConvention.trackSpanName, attributes: spanAttributes)

--- a/Sources/LaunchDarklyObservability/Plugin/LDValue+Attributes.swift
+++ b/Sources/LaunchDarklyObservability/Plugin/LDValue+Attributes.swift
@@ -1,0 +1,19 @@
+import LaunchDarkly
+import OpenTelemetryApi
+#if !LD_COCOAPODS
+import Common
+#endif
+
+extension LDValue {
+    /// Converts an object payload (e.g. a `track` event's `data`) into a flat
+    /// attribute map.
+    ///
+    /// Reuses `AttributeConverter` for the value mapping by first bridging to
+    /// Foundation, so scalar/array/object handling stays in one place. Only
+    /// object payloads have key/value members; scalar and array payloads map to
+    /// an empty dictionary.
+    package func toAttributes() -> [String: AttributeValue] {
+        guard case .object = self else { return [:] }
+        return AttributeConverter.convert((toFoundation() as? [String: Any]) ?? [:])
+    }
+}

--- a/Sources/LaunchDarklyObservability/Plugin/ObservabilityHook.swift
+++ b/Sources/LaunchDarklyObservability/Plugin/ObservabilityHook.swift
@@ -70,26 +70,9 @@ final class ObservabilityHook: Hook {
     }
 
     public func afterTrack(seriesContext: TrackSeriesContext) {
-        var attributes = [String: AttributeValue]()
-        if case let .object(data) = seriesContext.data {
-            for (k, v) in data {
-                if let attr = Self.attributeValue(from: v) {
-                    attributes[k] = attr
-                }
-            }
-        }
         delegate?.afterTrack(eventKey: seriesContext.key,
                              metricValue: seriesContext.metricValue,
-                             attributes: attributes,
+                             attributes: seriesContext.data?.toAttributes() ?? [:],
                              contextKeys: seriesContext.context.contextKeys())
-    }
-
-    private static func attributeValue(from value: LDValue) -> AttributeValue? {
-        switch value {
-        case .bool(let b): return .bool(b)
-        case .number(let n): return .double(n)
-        case .string(let s): return .string(s)
-        case .null, .array, .object: return nil
-        }
     }
 }

--- a/Sources/LaunchDarklyObservability/Plugin/ObservabilityHookExporter.swift
+++ b/Sources/LaunchDarklyObservability/Plugin/ObservabilityHookExporter.swift
@@ -13,7 +13,7 @@ import Common
 /// Receives track events and identify context keys so the single span emitter
 /// (`ObservabilityService`) can produce `track` spans and cache context keys.
 protocol TrackEmitting: AnyObject {
-    func track(name: String, value: Double?, attributes: [String: AttributeValue],
+    func track(name: String, metricValue: Double?, attributes: [String: AttributeValue],
                contextKeyAttributes: [String: AttributeValue]?)
     func updateCachedContextKeys(_ contextKeys: [String: String])
 }
@@ -165,7 +165,7 @@ extension ObservabilityHookExporter: ObservabilityHookExporting {
         }
         // Route through the single emitter so gating/caching stay in one place.
         trackEmitter?.track(name: eventKey,
-                            value: metricValue,
+                            metricValue: metricValue,
                             attributes: attributes,
                             contextKeyAttributes: contextKeyAttributes)
     }

--- a/Sources/LaunchDarklySessionReplay/Bridge/SessionReplayHookProxy.swift
+++ b/Sources/LaunchDarklySessionReplay/Bridge/SessionReplayHookProxy.swift
@@ -28,16 +28,8 @@ public final class SessionReplayHookProxy: NSObject {
     }
 
     @objc(afterTrackWithName:value:attributes:)
-    public func afterTrack(name: String, value: NSNumber?, attributes: NSDictionary) {
-        var attrs = [String: AttributeValue]()
-        for (k, v) in attributes {
-            guard let key = k as? String else { continue }
-            if let s = v as? String {
-                attrs[key] = .string(s)
-            } else if let n = v as? NSNumber {
-                attrs[key] = .double(n.doubleValue)
-            }
-        }
-        sessionReplayService.afterTrack(name: name, value: value?.doubleValue, attributes: attrs)
+    public func afterTrack(name: String, metricValue: NSNumber?, attributes: NSDictionary) {
+        let attrs = AttributeConverter.convert((attributes as? [String: Any]) ?? [:])
+        sessionReplayService.afterTrack(name: name, metricValue: metricValue?.doubleValue, attributes: attrs)
     }
 }

--- a/Sources/LaunchDarklySessionReplay/Bridge/SessionReplayHookProxy.swift
+++ b/Sources/LaunchDarklySessionReplay/Bridge/SessionReplayHookProxy.swift
@@ -26,4 +26,18 @@ public final class SessionReplayHookProxy: NSObject {
         }
         sessionReplayService.afterIdentify(contextKeys: keys, canonicalKey: canonicalKey, completed: completed)
     }
+
+    @objc(afterTrackWithName:value:attributes:)
+    public func afterTrack(name: String, value: NSNumber?, attributes: NSDictionary) {
+        var attrs = [String: AttributeValue]()
+        for (k, v) in attributes {
+            guard let key = k as? String else { continue }
+            if let s = v as? String {
+                attrs[key] = .string(s)
+            } else if let n = v as? NSNumber {
+                attrs[key] = .double(n.doubleValue)
+            }
+        }
+        sessionReplayService.afterTrack(name: name, value: value?.doubleValue, attributes: attrs)
+    }
 }

--- a/Sources/LaunchDarklySessionReplay/Exporter/RRWebEventGenerator.swift
+++ b/Sources/LaunchDarklySessionReplay/Exporter/RRWebEventGenerator.swift
@@ -267,7 +267,7 @@ actor RRWebEventGenerator {
     func trackEvent(itemPayload: TrackItemPayload) -> Event? {
         // Match the web `Track` custom event: a stringified JSON `{ data, value, event }`.
         let payload = TrackPayload(event: itemPayload.name,
-                                   value: itemPayload.value,
+                                   value: itemPayload.metricValue,
                                    data: itemPayload.attributes)
         guard let data = try? JSONEncoder().encode(payload),
               let payloadJSONString = String(data: data, encoding: .utf8) else {

--- a/Sources/LaunchDarklySessionReplay/Exporter/RRWebEventGenerator.swift
+++ b/Sources/LaunchDarklySessionReplay/Exporter/RRWebEventGenerator.swift
@@ -136,6 +136,11 @@ actor RRWebEventGenerator {
         case let pressItem as PressInteractionPayload:
             appendPressInteraction(payload: pressItem, events: &events)
             
+        case let trackItem as TrackItemPayload:
+            if let event = trackEvent(itemPayload: trackItem) {
+                events.append(event)
+            }
+            
         default:
             break // Item wasn't needed for SessionReplay
         }
@@ -252,6 +257,24 @@ actor RRWebEventGenerator {
         }
         
         let eventData = CustomEventData(tag: .identify, payload: userJSONString)
+        let event = Event(type: .Custom,
+                          data: AnyEventData(eventData),
+                          timestamp: itemPayload.timestamp,
+                          _sid: nextSid)
+        return event
+    }
+    
+    func trackEvent(itemPayload: TrackItemPayload) -> Event? {
+        // Match the web `Track` custom event: a stringified JSON `{ data, value, event }`.
+        let payload = TrackPayload(event: itemPayload.name,
+                                   value: itemPayload.value,
+                                   data: itemPayload.attributes)
+        guard let data = try? JSONEncoder().encode(payload),
+              let payloadJSONString = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+
+        let eventData = CustomEventData(tag: .track, payload: payloadJSONString)
         let event = Event(type: .Custom,
                           data: AnyEventData(eventData),
                           timestamp: itemPayload.timestamp,

--- a/Sources/LaunchDarklySessionReplay/Exporter/TrackItemPayload.swift
+++ b/Sources/LaunchDarklySessionReplay/Exporter/TrackItemPayload.swift
@@ -8,7 +8,7 @@ import LaunchDarklyObservability
 /// here so the same timeline event is produced in the replay.
 struct TrackItemPayload: EventQueueItemPayload {
     let name: String
-    let value: Double?
+    let metricValue: Double?
     let attributes: [String: String]
     var timestamp: TimeInterval
     let sessionId: String
@@ -24,12 +24,12 @@ struct TrackItemPayload: EventQueueItemPayload {
 
 extension TrackItemPayload {
     init(name: String,
-         value: Double?,
+         metricValue: Double?,
          attributes: [String: AttributeValue],
          timestamp: TimeInterval,
          sessionId: String) {
         self.name = name
-        self.value = value
+        self.metricValue = metricValue
         self.attributes = attributes.compactMapValues { Self.stringValue(from: $0) }
         self.timestamp = timestamp
         self.sessionId = sessionId

--- a/Sources/LaunchDarklySessionReplay/Exporter/TrackItemPayload.swift
+++ b/Sources/LaunchDarklySessionReplay/Exporter/TrackItemPayload.swift
@@ -1,0 +1,52 @@
+import Foundation
+import LaunchDarklyObservability
+
+/// Session-replay queue item for a custom analytics `track` event.
+///
+/// Mirrors the web SDK, where `LDClient.track` -> `afterTrack` hook -> `RecordSDK.track`
+/// emits an rrweb `Custom` event tagged `"Track"`. On iOS the LD `afterTrack` hook routes
+/// here so the same timeline event is produced in the replay.
+struct TrackItemPayload: EventQueueItemPayload {
+    let name: String
+    let value: Double?
+    let attributes: [String: String]
+    var timestamp: TimeInterval
+    let sessionId: String
+
+    var exporterClass: AnyClass {
+        SessionReplayExporter.self
+    }
+
+    func cost() -> Int {
+        (attributes.count + 1) * 100
+    }
+}
+
+extension TrackItemPayload {
+    init(name: String,
+         value: Double?,
+         attributes: [String: AttributeValue],
+         timestamp: TimeInterval,
+         sessionId: String) {
+        self.name = name
+        self.value = value
+        self.attributes = attributes.compactMapValues { Self.stringValue(from: $0) }
+        self.timestamp = timestamp
+        self.sessionId = sessionId
+    }
+
+    private static func stringValue(from value: AttributeValue) -> String? {
+        switch value {
+        case .array, .set, .boolArray, .intArray, .doubleArray, .stringArray:
+            return nil
+        case .string(let v):
+            return v
+        case .bool(let v):
+            return v.description
+        case .int(let v):
+            return String(v)
+        case .double(let v):
+            return String(v)
+        }
+    }
+}

--- a/Sources/LaunchDarklySessionReplay/RRWeb/CustomEventData.swift
+++ b/Sources/LaunchDarklySessionReplay/RRWeb/CustomEventData.swift
@@ -21,6 +21,14 @@ struct ClickPayload: Codable {
     var clickSelector: String
 }
 
+/// Mirrors the web `Track` custom-event payload (`{ ...metadata, event }`) emitted by
+/// `RecordSDK.track` -> `addCustomEvent('Track', stringify(...))`.
+struct TrackPayload: Codable {
+    var event: String
+    var value: Double?
+    var data: [String: String]
+}
+
 /// Unified wire payload for `CustomDataTag.press` (`"Press"`).
 /// `source` discriminates input origin: `"remote"`, `"physical-keyboard"`, or `"software-keyboard"`.
 /// `pressType` and `pressTypeSystemRaw` are only set when `source == "remote"`.

--- a/Sources/LaunchDarklySessionReplay/RRWeb/Event.swift
+++ b/Sources/LaunchDarklySessionReplay/RRWeb/Event.swift
@@ -50,6 +50,8 @@ struct AnyEventData: Codable {
                 try CustomEventData<String>(from: decoder)
             case .press:
                 try CustomEventData<PressPayload>(from: decoder)
+            case .track:
+                try CustomEventData<String>(from: decoder)
             }
         } else {
             throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: [], debugDescription: "Unexpected EventData"))

--- a/Sources/LaunchDarklySessionReplay/RRWeb/RRWebTypes.swift
+++ b/Sources/LaunchDarklySessionReplay/RRWeb/RRWebTypes.swift
@@ -67,4 +67,6 @@ enum CustomDataTag: String, Codable {
     case identify = "Identify"
     /// Non-spatial press: remote control, physical keyboard, or software keyboard. Payload: `PressPayload` with `source` discriminator.
     case press = "Press"
+    /// Custom analytics event produced by `LDClient.track` (or the manual track path). Payload: stringified JSON `{ "event", "value", "data" }`.
+    case track = "Track"
 }

--- a/Sources/LaunchDarklySessionReplay/SessionReplayHook.swift
+++ b/Sources/LaunchDarklySessionReplay/SessionReplayHook.swift
@@ -34,4 +34,32 @@ final class SessionReplayHook: Hook {
         )
         return seriesData
     }
+
+    public func afterTrack(seriesContext: TrackSeriesContext) {
+        guard let delegate else { return }
+
+        var attributes = [String: AttributeValue]()
+        if case let .object(data) = seriesContext.data {
+            for (k, v) in data {
+                if let attr = Self.attributeValue(from: v) {
+                    attributes[k] = attr
+                }
+            }
+        }
+
+        delegate.afterTrack(
+            name: seriesContext.key,
+            value: seriesContext.metricValue,
+            attributes: attributes
+        )
+    }
+
+    private static func attributeValue(from value: LDValue) -> AttributeValue? {
+        switch value {
+        case .bool(let b): return .bool(b)
+        case .number(let n): return .double(n)
+        case .string(let s): return .string(s)
+        case .null, .array, .object: return nil
+        }
+    }
 }

--- a/Sources/LaunchDarklySessionReplay/SessionReplayHook.swift
+++ b/Sources/LaunchDarklySessionReplay/SessionReplayHook.swift
@@ -38,28 +38,10 @@ final class SessionReplayHook: Hook {
     public func afterTrack(seriesContext: TrackSeriesContext) {
         guard let delegate else { return }
 
-        var attributes = [String: AttributeValue]()
-        if case let .object(data) = seriesContext.data {
-            for (k, v) in data {
-                if let attr = Self.attributeValue(from: v) {
-                    attributes[k] = attr
-                }
-            }
-        }
-
         delegate.afterTrack(
             name: seriesContext.key,
-            value: seriesContext.metricValue,
-            attributes: attributes
+            metricValue: seriesContext.metricValue,
+            attributes: seriesContext.data?.toAttributes() ?? [:]
         )
-    }
-
-    private static func attributeValue(from value: LDValue) -> AttributeValue? {
-        switch value {
-        case .bool(let b): return .bool(b)
-        case .number(let n): return .double(n)
-        case .string(let s): return .string(s)
-        case .null, .array, .object: return nil
-        }
     }
 }

--- a/Sources/LaunchDarklySessionReplay/SessionReplayService.swift
+++ b/Sources/LaunchDarklySessionReplay/SessionReplayService.swift
@@ -23,7 +23,7 @@ protocol SessionReplayServicing: AnyObject {
     
     func afterIdentify(contextKeys: [String: String], canonicalKey: String, completed: Bool)
 
-    func afterTrack(name: String, value: Double?, attributes: [String: AttributeValue])
+    func afterTrack(name: String, metricValue: Double?, attributes: [String: AttributeValue])
 }
 
 struct SessionReplayContext {
@@ -150,11 +150,11 @@ final class SessionReplayService: SessionReplayServicing {
         }
     }
     
-    func afterTrack(name: String, value: Double?, attributes: [String: AttributeValue]) {
+    func afterTrack(name: String, metricValue: Double?, attributes: [String: AttributeValue]) {
         let sessionId = observabilityContext.sessionManager.sessionInfo.id
         let payload = TrackItemPayload(
             name: name,
-            value: value,
+            metricValue: metricValue,
             attributes: attributes,
             timestamp: Date().timeIntervalSince1970,
             sessionId: sessionId

--- a/Sources/LaunchDarklySessionReplay/SessionReplayService.swift
+++ b/Sources/LaunchDarklySessionReplay/SessionReplayService.swift
@@ -22,6 +22,8 @@ protocol SessionReplayServicing: AnyObject {
     var isRunning: Bool { get }
     
     func afterIdentify(contextKeys: [String: String], canonicalKey: String, completed: Bool)
+
+    func afterTrack(name: String, value: Double?, attributes: [String: AttributeValue])
 }
 
 struct SessionReplayContext {
@@ -145,6 +147,20 @@ final class SessionReplayService: SessionReplayServicing {
                 sessionId: sessionId
             )
             await scheduleIdentifySession(identifyPayload: identifyPayload)
+        }
+    }
+    
+    func afterTrack(name: String, value: Double?, attributes: [String: AttributeValue]) {
+        let sessionId = observabilityContext.sessionManager.sessionInfo.id
+        let payload = TrackItemPayload(
+            name: name,
+            value: value,
+            attributes: attributes,
+            timestamp: Date().timeIntervalSince1970,
+            sessionId: sessionId
+        )
+        Task { [transportService] in
+            await transportService.eventQueue.send(payload)
         }
     }
     

--- a/TestApp/Sources/MainMenuViewModel.swift
+++ b/TestApp/Sources/MainMenuViewModel.swift
@@ -120,7 +120,7 @@ final class MainMenuViewModel: ObservableObject {
 		LDClient.get()?.track(
             key: "track-via-ld-observe",
             data: [
-                "test-string": "maui",
+                "test-string": "ios",
                 "test-true": true,
                 "test-false": false,
                 "test-integer": .number(42),
@@ -135,7 +135,7 @@ final class MainMenuViewModel: ObservableObject {
 		LDObserve.shared.track(
 			key: "track-via-ld-observe",
             data: [
-                "test-string": "maui",
+                "test-string": "ios",
                 "test-true": true,
                 "test-false": false,
                 "test-integer": .number(42),

--- a/TestApp/Sources/MainMenuViewModel.swift
+++ b/TestApp/Sources/MainMenuViewModel.swift
@@ -117,15 +117,31 @@ final class MainMenuViewModel: ObservableObject {
 	
 	func trackViaLDClient() {
 		// Records a track span automatically via the Observability afterTrack hook.
-		LDClient.get()?.track(key: "track-via-ld-client")
+		LDClient.get()?.track(
+            key: "track-via-ld-observe",
+            data: [
+                "test-string": "maui",
+                "test-true": true,
+                "test-false": false,
+                "test-integer": .number(42),
+                "test-double": 3.14
+            ],
+            metricValue: 7.0
+        )
 	}
 
 	func trackViaLDObserve() {
 		// Records a track span directly through the Observability API.
 		LDObserve.shared.track(
-			name: "track-via-ld-observe",
-			value: 7.0,
-			attributes: ["source": .string("ld-observe")]
+			key: "track-via-ld-observe",
+            data: [
+                "test-string": "maui",
+                "test-true": true,
+                "test-false": false,
+                "test-integer": .number(42),
+                "test-double": 3.14
+            ],
+            metricValue: 7.0
 		)
 	}
 

--- a/TestApp/Sources/MainMenuViewModel.swift
+++ b/TestApp/Sources/MainMenuViewModel.swift
@@ -125,8 +125,7 @@ final class MainMenuViewModel: ObservableObject {
                 "test-false": false,
                 "test-integer": .number(42),
                 "test-double": 3.14
-            ],
-            metricValue: 7.0
+            ]
         )
 	}
 
@@ -140,8 +139,7 @@ final class MainMenuViewModel: ObservableObject {
                 "test-false": false,
                 "test-integer": .number(42),
                 "test-double": 3.14
-            ],
-            metricValue: 7.0
+            ]
 		)
 	}
 

--- a/Tests/SessionReplayTests/RRWebEventGeneratorTests.swift
+++ b/Tests/SessionReplayTests/RRWebEventGeneratorTests.swift
@@ -218,6 +218,53 @@ struct RRWebEventGeneratorTests {
         #expect(payload?["pressType"] == nil)
     }
 
+    @Test("Appends Track custom event mirroring the web payload shape")
+    func appendsTrackEvent() async throws {
+        let generator = RRWebEventGenerator(
+            log: OSLog(subsystem: "test", category: "test"),
+            title: "Test",
+            method: .overlayTiles()
+        )
+        let trackPayload = TrackItemPayload(
+            name: "purchase",
+            value: 9.99,
+            attributes: ["currency": .string("USD"), "count": .int(2)],
+            timestamp: 42.0,
+            sessionId: "test-session"
+        )
+        let items: [EventQueueItem] = [EventQueueItem(payload: trackPayload)]
+        let events = await generator.generateEvents(items: items)
+        #expect(events.count == 1)
+        #expect(events[0].type == .Custom)
+        let encoded = try JSONEncoder().encode(events[0])
+        let json = try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        let data = json?["data"] as? [String: Any]
+        #expect(data?["tag"] as? String == "Track")
+        // Payload is a stringified JSON, matching the web `addCustomEvent('Track', stringify(...))`.
+        let payloadString = try #require(data?["payload"] as? String)
+        let payloadData = try #require(payloadString.data(using: .utf8))
+        let payloadJSON = try JSONSerialization.jsonObject(with: payloadData) as? [String: Any]
+        #expect(payloadJSON?["event"] as? String == "purchase")
+        #expect(payloadJSON?["value"] as? Double == 9.99)
+        let trackData = payloadJSON?["data"] as? [String: Any]
+        #expect(trackData?["currency"] as? String == "USD")
+        #expect(trackData?["count"] as? String == "2")
+    }
+
+    @Test("Track custom event decodes via AnyEventData round-trip")
+    func trackEventDecodesRoundTrip() throws {
+        let custom = CustomEventData(tag: .track, payload: "{\"event\":\"login\"}")
+        let event = Event(type: .Custom, data: AnyEventData(custom), timestamp: 10.0, _sid: 1)
+        let encoded = try JSONEncoder().encode(event)
+        let decoded = try JSONDecoder().decode(Event.self, from: encoded)
+        #expect(decoded.type == .Custom)
+        let roundTrip = try JSONEncoder().encode(decoded)
+        let json = try JSONSerialization.jsonObject(with: roundTrip) as? [String: Any]
+        let data = json?["data"] as? [String: Any]
+        #expect(data?["tag"] as? String == "Track")
+        #expect(data?["payload"] as? String == "{\"event\":\"login\"}")
+    }
+
     @Test("Press custom event decodes via AnyEventData round-trip")
     func pressEventDecodesRoundTrip() throws {
         let payload = PressPayload(source: "remote", pressType: "other", pressTypeSystemRaw: 77)

--- a/Tests/SessionReplayTests/RRWebEventGeneratorTests.swift
+++ b/Tests/SessionReplayTests/RRWebEventGeneratorTests.swift
@@ -227,7 +227,7 @@ struct RRWebEventGeneratorTests {
         )
         let trackPayload = TrackItemPayload(
             name: "purchase",
-            value: 9.99,
+            metricValue: 9.99,
             attributes: ["currency": .string("USD"), "count": .int(2)],
             timestamp: 42.0,
             sessionId: "test-session"


### PR DESCRIPTION
https://launchdarkly.atlassian.net/browse/O11Y-1538

## Summary

Wires the LaunchDarkly `afterTrack` hook into iOS Session Replay so that calling `LDClient.track(...)` produces a **Track** custom event on the replay timeline, matching the web SDK behavior.

In the web SDK, the `afterTrack` hook calls `record.track(key, { data, value })`, which emits an rrweb Custom event (`EventType.Custom = 5`) with `tag: "Track"` and a stringified-JSON payload `{ data, value, event }`. This PR reproduces that on iOS.

### Changes
- `RRWebTypes.swift` — new `CustomDataTag.track = "Track"`.
- `Event.swift` — decode the `.track` tag (string payload).
- `CustomEventData.swift` — `TrackPayload { event, value, data }` matching the web shape.
- `Exporter/TrackItemPayload.swift` (new) — an `EventQueueItemPayload` carrying name/value/attributes, routed to `SessionReplayExporter` (mirrors `IdentifyItemPayload`).
- `RRWebEventGenerator.swift` — builds the `.Custom` event with tag `.track` and a stringified-JSON payload.
- `SessionReplayService.swift` — `afterTrack(name:value:attributes:)` builds a `TrackItemPayload` and sends it to the event queue.
- `SessionReplayHook.swift` — implements the LD `afterTrack(seriesContext:)` hook.
- `Bridge/SessionReplayHookProxy.swift` — `@objc afterTrack` for the MAUI/C# bridge (parity with identify).

### Payload contract
Custom event `type = 5`, `data.tag = "Track"`, `data.payload` = string containing JSON `{ "event": "<key>", "value": <number|null>, "data": { ...string attrs } }`.

## Test plan
- [x] Added `appendsTrackEvent` and `trackEventDecodesRoundTrip` to `RRWebEventGeneratorTests.swift`.
- [x] `xcodebuild build-for-testing` succeeds for iOS Simulator.
- [x] `RRWebEventGeneratorTests` all pass (9/9).

Made with [Cursor](https://cursor.com)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public breaking change to LDObserve.track call shape; Session Replay adds a new ingestion tag/payload contract that backends and players must accept.
> 
> **Overview**
> **Session Replay** now records custom analytics on the replay timeline when `LDClient.track` (or the manual observability path) runs: the LD `afterTrack` hook is implemented for Session Replay, events are queued as `TrackItemPayload`, and **RRWeb** emits a `Custom` event with tag **`Track`** and a stringified JSON payload `{ event, value, data }` aligned with the web SDK.
> 
> **Observability** renames the public track API to **`LDObserve.track(key:data:metricValue:)`** (matching `LDClient.track`) and drops the old `name` / OpenTelemetry `attributes` overloads. Track `data` is converted via new **`LDValue.toAttributes()`** (shared with hooks); **`AttributeConverter`** is **public** for the MAUI bridge. Internal span emission still uses `metricValue` instead of `value`.
> 
> Docs, TestApp samples, and **RRWebEventGenerator** tests cover the new Track wire format.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85b7f323744da1b47fc0ef21ded8621ff3bf86c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->