### PR TITLE
feat: taps analytical options

### DIFF
--- a/LaunchDarklyObservability.podspec
+++ b/LaunchDarklyObservability.podspec
@@ -43,7 +43,7 @@ Pod::Spec.new do |s|
   # Common sources + LaunchDarkly SDK dependency
   s.subspec "Common" do |ss|
     ss.source_files = "Sources/Common/**/*.{swift,h,m}"
-    ss.dependency 'LaunchDarkly', '~> 11.1.0'
+    ss.dependency 'LaunchDarkly', '~> 11.2'
   end
 
   # JSONExporters subspec — OTLP/JSON wire-format models and adapters

--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ let config = { () -> LDConfig in
 
 `analytics` controls analytics telemetry, emitted as OpenTelemetry spans:
 
-- `taps` (default `.enabled`): emit a `click` span for each tap. Session Replay capture is unaffected by this flag.
+- `taps` (default `.enabled`): publish a `click` span for each detected tap. Tap detection is governed by `instrumentation.userTaps` (default `.enabled`); if that is disabled, no taps are issued and this flag has no effect. Session Replay capture is unaffected by either flag.
 - `trackEvents` (default `.enabled`): emit a `track` span when a custom event is tracked, either automatically via the LaunchDarkly `afterTrack` hook (`LDClient.track(...)`) or manually via `LDObserve.shared.track(...)`.
 
 Use the `.enabled` / `.disabled` presets, or configure fields individually with `Analytics(taps:trackEvents:)`.

--- a/Sources/LaunchDarklyObservability/API/ObservabilityOptions.swift
+++ b/Sources/LaunchDarklyObservability/API/ObservabilityOptions.swift
@@ -151,6 +151,11 @@ public struct ObservabilityOptions {
     }
     public struct Instrumentation {
         let urlSession: FeatureFlag
+        /// Whether to run the user-tap detection machinery (issuing tap events from the
+        /// captured touch stream). Publishing those taps as OpenTelemetry `click` spans is
+        /// governed separately by ``Analytics/taps``; Session Replay capture is unaffected
+        /// by either flag.
+        let userTaps: FeatureFlag
         let memory: FeatureFlag
         let memoryWarnings: FeatureFlag
         let cpu: FeatureFlag
@@ -158,12 +163,14 @@ public struct ObservabilityOptions {
         
         public init(
             urlSession: FeatureFlag = .disabled,
+            userTaps: FeatureFlag = .enabled,
             memory: FeatureFlag = .disabled,
             memoryWarnings: FeatureFlag = .disabled,
             cpu: FeatureFlag = .disabled,
             launchTimes: FeatureFlag = .disabled
         ) {
             self.urlSession = urlSession
+            self.userTaps = userTaps
             self.memory = memory
             self.memoryWarnings = memoryWarnings
             self.cpu = cpu
@@ -174,8 +181,10 @@ public struct ObservabilityOptions {
     ///
     /// Controls which user-behaviour signals are emitted as OpenTelemetry spans.
     public struct Analytics {
-        /// Whether to emit a `click` span for each tap. Capture for Session Replay
-        /// is unaffected by this flag.
+        /// Whether to publish a `click` span for each detected tap. Tap detection itself
+        /// is governed by ``Instrumentation/userTaps``; if that is disabled no taps are
+        /// issued and this flag has no effect. Capture for Session Replay is unaffected
+        /// by either flag.
         let taps: FeatureFlag
         /// Whether to emit a `track` span when a custom event is tracked
         /// (via the LD `afterTrack` hook or ``LDObserve/track(name:value:attributes:)``).
@@ -252,7 +261,8 @@ public struct ObservabilityOptions {
     ///   - crashReporting: Crash-reporting configuration, including which provider to use
     ///     (KSCrash or MetricKit). Defaults to ``CrashReporting/enabled`` (KSCrash).
     ///   - instrumentation: Per-feature toggles for automatic instrumentation (URLSession,
-    ///     memory, CPU, launch times, …). Defaults to all features disabled.
+    ///     user taps, memory, CPU, launch times, …). Defaults to all features disabled
+    ///     except user-tap detection, which is enabled.
     ///   - analytics: Toggles for analytics telemetry (taps, track events).
     ///     Defaults to taps enabled and track events enabled.
     public init(

--- a/Sources/LaunchDarklyObservability/Client/ObservabilityService.swift
+++ b/Sources/LaunchDarklyObservability/Client/ObservabilityService.swift
@@ -176,10 +176,14 @@ final class ObservabilityService: InternalObserve {
         )
         self.tracer = appTraceClient
         
-        let tapsEnabled = options.analytics.taps.isEnabled
+        // `instrumentation.userTaps` enables the tap-detection machinery (issuing tap
+        // events); `analytics.taps` governs whether a detected tap is published as an OTel
+        // `click` span. Capture still flows to Session Replay regardless of either flag.
+        let userTapsEnabled = options.instrumentation.userTaps.isEnabled
+        let publishTaps = options.analytics.taps.isEnabled
         let userInteractionManager = UserInteractionManager(options: options, sessionManaging: sessionManager) { interaction in
-            // Gate only the telemetry span; capture still flows to Session Replay.
-            guard tapsEnabled else { return }
+            guard userTapsEnabled else { return }
+            guard publishTaps else { return }
             interaction.startEndSpan(tracer: tracerDecorator)
         }
         self.userInteractionManager = userInteractionManager

--- a/TestApp/Sources/MainMenuView.swift
+++ b/TestApp/Sources/MainMenuView.swift
@@ -272,18 +272,21 @@ struct MainMenuView: View {
                     .buttonStyle(.borderedProminent)
             }
 
-            Text("Customer API")
+            Text("Error")
+                .fontWeight(.bold)
+
+            Button {
+                viewModel.recordError()
+            } label: {
+                Text("Error")
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(.red)
+
+            Text("Logs")
                 .fontWeight(.bold)
 
             HStack {
-                Button {
-                    viewModel.recordError()
-                } label: {
-                    Text("Error")
-                }
-                .buttonStyle(.borderedProminent)
-                .tint(.red)
-
                 Button {
                     viewModel.recordLogs()
                 } label: {
@@ -298,6 +301,9 @@ struct MainMenuView: View {
                 }
                 .buttonStyle(.borderedProminent)
             }
+
+            Text("Traces")
+                .fontWeight(.bold)
 
             HStack {
                 Button {


### PR DESCRIPTION
Refactor taps analytical options

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default instrumentation surface and telemetry gating for taps; integrators disabling `userTaps` or only toggling `analytics.taps` will see different click-span behavior than before.
> 
> **Overview**
> Splits **tap analytics** into two independent toggles: **`instrumentation.userTaps`** (default **enabled**) controls whether tap-detection runs from the touch stream, and **`analytics.taps`** controls whether detected taps are exported as OpenTelemetry **`click`** spans. **`ObservabilityService`** now requires both flags before emitting those spans; Session Replay is unchanged.
> 
> Docs and API comments describe the split and update default instrumentation wording (user-tap detection on by default). The CocoaPods **`LaunchDarkly`** dependency is relaxed to **`~> 11.2`**. The TestApp observability menu is regrouped (Error / Logs / Traces sections).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbdd462da6ebf84eb2809e1844b2ada358f01cfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->