### PR TITLE
feat: richer Session Replay click descriptions (target text/selector)

### DIFF
--- a/Sources/LaunchDarklyObservability/API/Observe.swift
+++ b/Sources/LaunchDarklyObservability/API/Observe.swift
@@ -87,6 +87,11 @@ public protocol TracesApi {
     /// - name The name of the span
     /// - attributes The attributes to record with the span
     func startSpan(name: String, attributes: [String : AttributeValue]) -> Span
+    /// Start a span with an explicit kind.
+    /// - name The name of the span
+    /// - attributes The attributes to record with the span
+    /// - spanKind The kind of the span (defaults to `.client` for most spans)
+    func startSpan(name: String, attributes: [String : AttributeValue], spanKind: SpanKind) -> Span
 }
 
 extension TracesApi {
@@ -96,5 +101,11 @@ extension TracesApi {
 
     public func startSpan(name: String) -> Span {
         startSpan(name: name, attributes: [:])
+    }
+
+    /// Default implementation forwards to ``startSpan(name:attributes:)``, leaving the span kind
+    /// to the implementation's default. Conformers that can honor a specific kind override this.
+    public func startSpan(name: String, attributes: [String : AttributeValue], spanKind: SpanKind) -> Span {
+        startSpan(name: name, attributes: attributes)
     }
 }

--- a/Sources/LaunchDarklyObservability/Client/ObservabilityService.swift
+++ b/Sources/LaunchDarklyObservability/Client/ObservabilityService.swift
@@ -197,7 +197,7 @@ final class ObservabilityService: InternalObserve {
         let userInteractionManager = UserInteractionManager(options: options, sessionManaging: sessionManager) { interaction in
             guard userTapsEnabled else { return }
             guard publishTaps else { return }
-            interaction.startEndSpan(tracer: tracerDecorator)
+            interaction.startEndSpan(tracer: tracerDecorator, log: options.log)
         }
         self.userInteractionManager = userInteractionManager
         

--- a/Sources/LaunchDarklyObservability/Client/ObservabilityService.swift
+++ b/Sources/LaunchDarklyObservability/Client/ObservabilityService.swift
@@ -197,7 +197,7 @@ final class ObservabilityService: InternalObserve {
         let userInteractionManager = UserInteractionManager(options: options, sessionManaging: sessionManager) { interaction in
             guard userTapsEnabled else { return }
             guard publishTaps else { return }
-            interaction.startEndSpan(tracer: tracerDecorator, log: options.log)
+            interaction.startEndSpan(tracer: tracerDecorator)
         }
         self.userInteractionManager = userInteractionManager
         

--- a/Sources/LaunchDarklyObservability/Plugin/ObservabilityHookExporter.swift
+++ b/Sources/LaunchDarklyObservability/Plugin/ObservabilityHookExporter.swift
@@ -117,7 +117,7 @@ extension ObservabilityHookExporter: ObservabilityHookExporting {
         attributes[Self.SEMCONV_FEATURE_FLAG_PROVIDER_NAME] = .string(Self.PROVIDER_NAME)
         attributes[Self.SEMCONV_FEATURE_FLAG_CONTEXT_ID] = .string(contextKey)
 
-        let span = traceClient.startSpan(name: Self.FEATURE_FLAG_SPAN_NAME, attributes: attributes)
+        let span = traceClient.startSpan(name: Self.FEATURE_FLAG_SPAN_NAME, attributes: attributes, spanKind: .internal)
 
         if let (_, evictedSpan) = spans.setValue(span, forKey: evaluationId) {
             evictedSpan.end()

--- a/Sources/LaunchDarklyObservability/Traces/TraceClient.swift
+++ b/Sources/LaunchDarklyObservability/Traces/TraceClient.swift
@@ -31,6 +31,19 @@ final class TraceClient: TracesApi {
         let span = builder.startSpan()
         return span
     }
+
+    /// Starts a span with an explicit kind. Used for the few spans that must not use the
+    /// default `.client` kind (e.g. flag evaluations, which are `.internal`).
+    func startSpan(name: String, attributes: [String : AttributeValue], spanKind: SpanKind) -> any Span {
+        let builder = tracer.spanBuilder(spanName: name)
+        builder.setSpanKind(spanKind: spanKind)
+        attributes.forEach {
+            builder.setAttribute(key: $0.key, value: $0.value)
+        }
+
+        let span = builder.startSpan()
+        return span
+    }
 }
 
 /// Internal method used to set span start date

--- a/Sources/LaunchDarklyObservability/Traces/TracerDecorator.swift
+++ b/Sources/LaunchDarklyObservability/Traces/TracerDecorator.swift
@@ -28,6 +28,10 @@ final class TracerDecorator: Tracer {
     func spanBuilder(spanName: String) -> any SpanBuilder {
         let builder = tracer.spanBuilder(spanName: spanName)
 
+        // Spans default to `.client`; callers that need a different kind (e.g. flag
+        // evaluations, which are `.internal`) override this after building.
+        builder.setSpanKind(spanKind: .client)
+
         if let parent = OpenTelemetry.instance.contextProvider.activeSpan {
             builder.setParent(parent)
         }
@@ -68,14 +72,16 @@ extension TracerDecorator: TracesApi {
 
 /// Internal method used to set span start date
 extension Tracer {
-    func startSpan(name: String, attributes: [String : AttributeValue], startTime: Date) -> any Span {
+    func startSpan(name: String, attributes: [String : AttributeValue], startTime: Date, spanKind: SpanKind = .client) -> any Span {
         let builder = spanBuilder(spanName: name)
+        builder.setSpanKind(spanKind: spanKind)
         attributes.forEach {
             builder.setAttribute(key: $0.key, value: $0.value)
         }
         
         builder.setStartTime(time: startTime)
-        
+
+ 
         let span = builder.startSpan()
         return span
     }

--- a/Sources/LaunchDarklyObservability/UIInteractions/UInteraction+Span.swift
+++ b/Sources/LaunchDarklyObservability/UIInteractions/UInteraction+Span.swift
@@ -20,7 +20,8 @@ extension TouchInteraction {
 
         let span = tracer.startSpan(name: SemanticConvention.clickSpanName,
                                     attributes: attributes,
-                                    startTime: Date(timeIntervalSince1970: startTimestamp))
+                                    startTime: Date(timeIntervalSince1970: startTimestamp),
+                                    spanKind: .client)
         span.end(time: Date(timeIntervalSince1970: timestamp))
     }
 }

--- a/Sources/LaunchDarklyObservability/UIInteractions/UInteraction+Span.swift
+++ b/Sources/LaunchDarklyObservability/UIInteractions/UInteraction+Span.swift
@@ -1,8 +1,7 @@
 import Foundation
-import OSLog
 
 extension TouchInteraction {
-    func startEndSpan(tracer: Tracer, log: OSLog) {
+    func startEndSpan(tracer: Tracer) {
         guard case let .touchUp(point) = kind else { return }
 
         // Per analytics-taxonomy §4.1 `click`: one event for all element types,
@@ -23,29 +22,5 @@ extension TouchInteraction {
                                     attributes: attributes,
                                     startTime: Date(timeIntervalSince1970: startTimestamp))
         span.end(time: Date(timeIntervalSince1970: timestamp))
-
-        #if DEBUG
-        logClickSpanShape(name: SemanticConvention.clickSpanName, attributes: attributes, log: log)
-        #endif
     }
-
-    #if DEBUG
-    /// Logs the JSON shape of the OTel `click` span (name + `event.*` attributes) for debugging.
-    private func logClickSpanShape(name: String, attributes: [String: AttributeValue], log: OSLog) {
-        var jsonAttributes: [String: Any] = [:]
-        for (key, value) in attributes {
-            switch value {
-            case .string(let s): jsonAttributes[key] = s
-            case .int(let i): jsonAttributes[key] = i
-            case .double(let d): jsonAttributes[key] = d
-            case .bool(let b): jsonAttributes[key] = b
-            default: jsonAttributes[key] = String(describing: value)
-            }
-        }
-        let shape: [String: Any] = ["span": name, "attributes": jsonAttributes]
-        guard let data = try? JSONSerialization.data(withJSONObject: shape, options: [.prettyPrinted, .sortedKeys]),
-              let json = String(data: data, encoding: .utf8) else { return }
-        os_log("%{public}@", log: log, type: .debug, "[Otel Click] \(json)")
-    }
-    #endif
 }

--- a/Sources/LaunchDarklyObservability/UIInteractions/UInteraction+Span.swift
+++ b/Sources/LaunchDarklyObservability/UIInteractions/UInteraction+Span.swift
@@ -1,7 +1,8 @@
 import Foundation
+import OSLog
 
 extension TouchInteraction {
-    func startEndSpan(tracer: Tracer) {
+    func startEndSpan(tracer: Tracer, log: OSLog) {
         guard case let .touchUp(point) = kind else { return }
 
         // Per analytics-taxonomy §4.1 `click`: one event for all element types,
@@ -22,5 +23,29 @@ extension TouchInteraction {
                                     attributes: attributes,
                                     startTime: Date(timeIntervalSince1970: startTimestamp))
         span.end(time: Date(timeIntervalSince1970: timestamp))
+
+        #if DEBUG
+        logClickSpanShape(name: SemanticConvention.clickSpanName, attributes: attributes, log: log)
+        #endif
     }
+
+    #if DEBUG
+    /// Logs the JSON shape of the OTel `click` span (name + `event.*` attributes) for debugging.
+    private func logClickSpanShape(name: String, attributes: [String: AttributeValue], log: OSLog) {
+        var jsonAttributes: [String: Any] = [:]
+        for (key, value) in attributes {
+            switch value {
+            case .string(let s): jsonAttributes[key] = s
+            case .int(let i): jsonAttributes[key] = i
+            case .double(let d): jsonAttributes[key] = d
+            case .bool(let b): jsonAttributes[key] = b
+            default: jsonAttributes[key] = String(describing: value)
+            }
+        }
+        let shape: [String: Any] = ["span": name, "attributes": jsonAttributes]
+        guard let data = try? JSONSerialization.data(withJSONObject: shape, options: [.prettyPrinted, .sortedKeys]),
+              let json = String(data: data, encoding: .utf8) else { return }
+        os_log("%{public}@", log: log, type: .debug, "[Otel Click] \(json)")
+    }
+    #endif
 }

--- a/Sources/LaunchDarklyObservability/UIInteractions/ViewInfo.swift
+++ b/Sources/LaunchDarklyObservability/UIInteractions/ViewInfo.swift
@@ -40,13 +40,19 @@ extension UIView {
             return ViewInfo(title: firstNonEmpty(label.text, self.accessibilityLabel), category: "label")
         }
         if let tf = self as? UITextField {
-            return ViewInfo(title: firstNonEmpty(tf.text, tf.placeholder, self.accessibilityLabel), category: "textField")
+            // Never capture an input's typed value (passwords, emails, etc.) - only the
+            // placeholder / accessibility label, which are developer-set, non-sensitive labels.
+            return ViewInfo(title: firstNonEmpty(tf.placeholder, self.accessibilityLabel), category: "textField")
         }
         if let tv = self as? UITextView {
-            return ViewInfo(title: firstNonEmpty(tv.text, self.accessibilityLabel), category: "textView")
+            // Editable text views hold user input; capture only the label. Non-editable text views
+            // are display content (label-like) and safe to read.
+            let title = tv.isEditable ? self.accessibilityLabel : firstNonEmpty(tv.text, self.accessibilityLabel)
+            return ViewInfo(title: title, category: "textView")
         }
         if let sb = self as? UISearchBar {
-            return ViewInfo(title: firstNonEmpty(sb.text, sb.placeholder, self.accessibilityLabel), category: "searchBar")
+            // Never capture the typed search query - only the placeholder / accessibility label.
+            return ViewInfo(title: firstNonEmpty(sb.placeholder, self.accessibilityLabel), category: "searchBar")
         }
         if let seg = self as? UISegmentedControl {
             let selected = seg.selectedSegmentIndex

--- a/Sources/LaunchDarklyObservability/UIInteractions/ViewInfo.swift
+++ b/Sources/LaunchDarklyObservability/UIInteractions/ViewInfo.swift
@@ -78,6 +78,10 @@ extension UIView {
 
     // Depth-first search for a sensible text inside subviews (UILabel/UIButton)
     private func firstDescendantTitle() -> String? {
+        // Never read or descend into text-input views. They render typed values through
+        // private label subviews, so scanning descendants would leak user input
+        // (passwords, emails, search queries, etc.) into the captured title.
+        if isSensitiveTextInput { return nil }
         if let label = self as? UILabel, let t = cleaned(label.text) { return t }
         if let btn = self as? UIButton {
             return firstNonEmpty(btn.titleLabel?.text, btn.currentTitle, btn.title(for: .normal), btn.attributedTitle(for: .normal)?.string)
@@ -86,6 +90,15 @@ extension UIView {
             if let t = sub.firstDescendantTitle() { return t }
         }
         return nil
+    }
+
+    // Views that hold user-typed input. Their values must never be captured, and we must
+    // not descend into them since their text is rendered via internal subviews.
+    private var isSensitiveTextInput: Bool {
+        if self is UITextField { return true }
+        if self is UISearchBar { return true }
+        if let textView = self as? UITextView { return textView.isEditable }
+        return false
     }
 
     private func allSegmentTitles(_ seg: UISegmentedControl) -> String? {

--- a/Sources/LaunchDarklySessionReplay/Exporter/RRWebEventGenerator.swift
+++ b/Sources/LaunchDarklySessionReplay/Exporter/RRWebEventGenerator.swift
@@ -53,10 +53,8 @@ actor RRWebEventGenerator {
     private var stats: SessionReplayStats?
     private let isDebug = false
     private var nodeIds: [ImageSignature: Int] = [:]
-    private let log: OSLog
     
     init(log: OSLog, title: String, method _: SessionReplayOptions.CompressionMethod) {
-        self.log = log
         if isDebug {
             self.stats = SessionReplayStats(log: log)
         }
@@ -243,11 +241,6 @@ actor RRWebEventGenerator {
                           data: AnyEventData(eventData),
                           timestamp: interaction.timestamp,
                           _sid: nextSid)
-        #if DEBUG
-        if let data = try? JSONEncoder().encode(event), let json = String(data: data, encoding: .utf8) {
-            os_log("%{public}@", log: log, type: .debug, "[SR Click] \(json)")
-        }
-        #endif
         return event
     }
     

--- a/Sources/LaunchDarklySessionReplay/Exporter/RRWebEventGenerator.swift
+++ b/Sources/LaunchDarklySessionReplay/Exporter/RRWebEventGenerator.swift
@@ -53,8 +53,10 @@ actor RRWebEventGenerator {
     private var stats: SessionReplayStats?
     private let isDebug = false
     private var nodeIds: [ImageSignature: Int] = [:]
+    private let log: OSLog
     
     init(log: OSLog, title: String, method _: SessionReplayOptions.CompressionMethod) {
+        self.log = log
         if isDebug {
             self.stats = SessionReplayStats(log: log)
         }
@@ -228,14 +230,24 @@ actor RRWebEventGenerator {
     func clickEvent(interaction: TouchInteraction) -> Event? {
         guard case .touchDown = interaction.kind else { return nil }
         
+        // Mirror the web `Click` payload (`highlight-run` ClickListener):
+        // - clickTarget: element identifier (web: full CSS selector path; iOS analog: class name)
+        // - clickTextContent: the element's visible text (web: `target.textContent`)
+        // - clickSelector: simple selector (web: `#id` else tag; iOS analog: a11y id else class name)
+        let target = interaction.target
         let eventData = CustomEventData(tag: .click, payload: ClickPayload(
-            clickTarget: interaction.target?.className ?? "",
-            clickTextContent: interaction.target?.accessibilityIdentifier ?? "",
-            clickSelector: interaction.target?.accessibilityIdentifier ?? "view"))
+            clickTarget: target?.className ?? "",
+            clickTextContent: target?.text ?? "",
+            clickSelector: target?.accessibilityIdentifier ?? target?.className ?? "view"))
         let event = Event(type: .Custom,
                           data: AnyEventData(eventData),
                           timestamp: interaction.timestamp,
                           _sid: nextSid)
+        #if DEBUG
+        if let data = try? JSONEncoder().encode(event), let json = String(data: data, encoding: .utf8) {
+            os_log("%{public}@", log: log, type: .debug, "[SR Click] \(json)")
+        }
+        #endif
         return event
     }
     


### PR DESCRIPTION
## Summary
- Populate the SR `Click` payload's `clickTextContent` from the tapped element's visible text (previously the accessibility identifier, usually empty) and fall back to the class name for `clickSelector`, matching the web `Click` semantics so the session player shows a meaningful description.
- Add **temporary** debug logs of the JSON shapes for both the OTel `click` span and the SR `Click` custom event.

## Note
The debug log lines are intentional and will be removed before release.

## Test plan
- [ ] Tap UI elements; confirm `[Otel Click]` and `[SR Click]` debug logs show populated `event.text` / `clickTextContent`.
- [ ] Verify the session player renders a non-empty click description.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches UI text extraction for observability/replay (privacy-sensitive) and changes default span kind behavior across tracing, though inputs are explicitly redacted.
> 
> **Overview**
> Improves **click descriptions** in Session Replay and OTel by feeding the RRWeb `Click` custom event from the tapped element’s **visible title** (`clickTextContent`) and **accessibility id or class name** (`clickSelector`), aligned with web `Click` semantics so the player shows meaningful labels instead of empty a11y ids.
> 
> **Privacy:** `ViewInfo` no longer reads **user-typed** values from `UITextField`, `UISearchBar`, or editable `UITextView`, and blocks descendant scans into those views so passwords, emails, and queries are not captured in titles used for analytics/replay.
> 
> **Tracing:** Adds optional **`spanKind`** on `TracesApi` / `TraceClient`, defaults new spans to **`.client`** in `TracerDecorator`, marks flag **evaluation** spans as **`.internal`**, and passes **`.client`** explicitly for UI **click** spans.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46ea00035dd4261d37a086ec289006f4308855c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->