### PR TITLE
feat: dictionary-based track API and Obj-C track bridge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ DerivedData/
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
 Package.resolved
-Secrets.xcconfig
+*.xcconfig

--- a/README.md
+++ b/README.md
@@ -381,13 +381,13 @@ LDObserve.shared.recordIncr(metric: .init(name: "page_views", value: 1.0))
 LDObserve.shared.recordHistogram(metric: .init(name: "response_time", value: 150.0))
 LDObserve.shared.recordUpDownCounter(metric: .init(name: "active_connections", value: 1.0))
 
-// Record logs
+// Record logs — pass attributes as a plain dictionary via `properties`.
 LDObserve.shared.recordLog(
     message: "User performed action",
     severity: .info,
-    attributes: [
-        "user_id": .string("12345"),
-        "action": .string("button_click")
+    properties: [
+        "user_id": "12345",
+        "action": "button_click"
     ]
 )
 
@@ -403,9 +403,9 @@ LDObserve.shared.recordError(
 // Create spans for tracing
 let span = LDObserve.shared.startSpan(
     name: "api_request",
-    attributes: [
-        "endpoint": .string("/api/users"),
-        "method": .string("GET")
+    properties: [
+        "endpoint": "/api/users",
+        "method": "GET"
     ]
 )
 
@@ -415,10 +415,17 @@ span.end()
 // (Calling LDClient.get()?.track(key:) records the same span automatically via the afterTrack hook.)
 LDObserve.shared.track(
     key: "checkout_completed",
-    data: ["currency": "USD"],
+    properties: ["currency": "USD"],
     metricValue: 42.0
 )
 ```
+
+`recordLog`, `startSpan`, and `track` accept attributes/data as a plain Swift
+dictionary via the `properties:` label — pass `String`, `Bool`, `Int`, `Double`,
+arrays, and nested dictionaries directly, with no need to import `OpenTelemetryApi`
+or build `AttributeValue`s. The `attributes:` (`AttributeValue`) overloads remain
+available when you need precise OpenTelemetry typing (as shown for `recordError`
+above).
 
 ### Tracking Screen Views
 
@@ -522,6 +529,29 @@ LDObserve.shared.trackScreenView(
 // Convenience overloads:
 LDObserve.shared.trackScreenView(name: "Profile")
 LDObserve.shared.trackScreenView(name: "Profile", category: "Account")
+```
+
+You can attach custom attributes to the `screen_view` span via the optional
+`properties:` parameter — a plain dictionary, using the same conversion rules as a
+`track` event's `properties` (no need to build `AttributeValue`s). Custom
+properties are applied at lower precedence than the reserved `event.*` taxonomy
+fields, so they can never clobber them:
+
+```swift
+LDObserve.shared.trackScreenView(
+    name: "Profile",
+    screenClass: "ProfileView",
+    screenId: "MyApp.ProfileView",
+    category: "Account",
+    properties: [
+        "tab": "overview",
+        "is_owner": true
+    ]
+)
+
+// Also available on the convenience overloads:
+LDObserve.shared.trackScreenView(name: "Profile", properties: ["tab": "overview"])
+LDObserve.shared.trackScreenView(name: "Profile", category: "Account", properties: ["tab": "overview"])
 ```
 
 Manual `trackScreenView(...)` calls work even when automatic detection (`instrumentation.screens`) is disabled. The emitted `screen_view` span is still gated by `analytics.screenViews`.

--- a/Sources/LaunchDarklyObservability/API/LDObserve.swift
+++ b/Sources/LaunchDarklyObservability/API/LDObserve.swift
@@ -68,11 +68,11 @@ extension LDObserve: Observe {
         client.startSpan(name: name, attributes: attributes)
     }
 
-    public func track(key: String, data: [String: Any]? = nil, metricValue: Double? = nil) {
-        client.track(key: key, data: data, metricValue: metricValue)
+    public func track(key: String, properties: [String: Any]? = nil, metricValue: Double? = nil) {
+        client.track(key: key, properties: properties, metricValue: metricValue)
     }
 
-    public func trackScreenView(name: String, screenClass: String?, screenId: String?, category: String?) {
-        client.trackScreenView(name: name, screenClass: screenClass, screenId: screenId, category: category)
+    public func trackScreenView(name: String, screenClass: String?, screenId: String?, category: String?, properties: [String: Any]?) {
+        client.trackScreenView(name: name, screenClass: screenClass, screenId: screenId, category: category, properties: properties)
     }
 }

--- a/Sources/LaunchDarklyObservability/API/LDObserve.swift
+++ b/Sources/LaunchDarklyObservability/API/LDObserve.swift
@@ -68,7 +68,7 @@ extension LDObserve: Observe {
         client.startSpan(name: name, attributes: attributes)
     }
 
-    public func track(key: String, data: LDValue? = nil, metricValue: Double? = nil) {
+    public func track(key: String, data: [String: Any]? = nil, metricValue: Double? = nil) {
         client.track(key: key, data: data, metricValue: metricValue)
     }
 

--- a/Sources/LaunchDarklyObservability/API/ObservabilityOptions.swift
+++ b/Sources/LaunchDarklyObservability/API/ObservabilityOptions.swift
@@ -194,7 +194,7 @@ public struct ObservabilityOptions {
         /// by either flag.
         let taps: FeatureFlag
         /// Whether to emit a `track` span when a custom event is tracked
-        /// (via the LD `afterTrack` hook or ``LDObserve/track(key:data:metricValue:)``).
+        /// (via the LD `afterTrack` hook or ``LDObserve/track(key:properties:metricValue:)``).
         let trackEvents: FeatureFlag
         /// Whether to emit a `screen_view` span when a screen is shown
         /// (automatically via the `UIViewController` swizzle or manually via

--- a/Sources/LaunchDarklyObservability/API/Observe.swift
+++ b/Sources/LaunchDarklyObservability/API/Observe.swift
@@ -48,7 +48,7 @@ extension Observe {
 
     /// Convenience that omits the screen class/id. See the full overload for the
     /// `properties` semantics.
-    public func trackScreenView(name: String, category: String? = nil, properties: [String: Any]?) {
+    public func trackScreenView(name: String, category: String?, properties: [String: Any]?) {
         trackScreenView(name: name, screenClass: nil, screenId: nil, category: category, properties: properties)
     }
 

--- a/Sources/LaunchDarklyObservability/API/Observe.swift
+++ b/Sources/LaunchDarklyObservability/API/Observe.swift
@@ -10,13 +10,15 @@ public protocol Observe: AnyObject, MetricsApi, LogsApi, TracesApi, ObserveConte
     ///
     /// Mirrors `LDClient.track(key:data:metricValue:)` so the same call shape
     /// works whether the event is recorded through the LaunchDarkly client (via
-    /// the `afterTrack` hook) or directly through this API.
+    /// the `afterTrack` hook) or directly through this API. `data` is a plain
+    /// dictionary so callers need not depend on `LDValue`.
     /// - Parameters:
     ///   - key: The key for the event.
-    ///   - data: The data associated with the event, if any.
+    ///   - data: The data associated with the event, if any. Object members are
+    ///     attached as span attributes.
     ///   - metricValue: A numeric value used by LaunchDarkly experimentation for
     ///     numeric custom metrics, if any.
-    func track(key: String, data: LDValue?, metricValue: Double?)
+    func track(key: String, data: [String: Any]?, metricValue: Double?)
     /// Manually record a `screen_view` event as a `screen_view` span.
     ///
     /// Use this for screens that automatic capture cannot observe (e.g. pure

--- a/Sources/LaunchDarklyObservability/API/Observe.swift
+++ b/Sources/LaunchDarklyObservability/API/Observe.swift
@@ -8,17 +8,18 @@ public protocol Observe: AnyObject, MetricsApi, LogsApi, TracesApi, ObserveConte
     func start()
     /// Record a custom track event as a `track` span.
     ///
-    /// Mirrors `LDClient.track(key:data:metricValue:)` so the same call shape
-    /// works whether the event is recorded through the LaunchDarkly client (via
-    /// the `afterTrack` hook) or directly through this API. `data` is a plain
-    /// dictionary so callers need not depend on `LDValue`.
+    /// Mirrors `LDClient.track(...)` so the same call shape works whether the
+    /// event is recorded through the LaunchDarkly client (via the `afterTrack`
+    /// hook) or directly through this API. The payload is passed as `properties`,
+    /// a plain dictionary, so callers need not depend on `LDValue` — matching the
+    /// `properties:` overloads of `recordLog`/`startSpan`.
     /// - Parameters:
     ///   - key: The key for the event.
-    ///   - data: The data associated with the event, if any. Object members are
-    ///     attached as span attributes.
+    ///   - properties: The data associated with the event, if any. Object members
+    ///     are attached as span attributes.
     ///   - metricValue: A numeric value used by LaunchDarkly experimentation for
     ///     numeric custom metrics, if any.
-    func track(key: String, data: [String: Any]?, metricValue: Double?)
+    func track(key: String, properties: [String: Any]?, metricValue: Double?)
     /// Manually record a `screen_view` event as a `screen_view` span.
     ///
     /// Use this for screens that automatic capture cannot observe (e.g. pure
@@ -29,16 +30,31 @@ public protocol Observe: AnyObject, MetricsApi, LogsApi, TracesApi, ObserveConte
     ///   - screenClass: The screen's class/type (`event.screen_class`).
     ///   - screenId: A stable screen identifier (`event.screen_id`).
     ///   - category: An optional screen group (`event.category`).
-    func trackScreenView(name: String, screenClass: String?, screenId: String?, category: String?)
+    ///   - properties: Optional custom attributes, supplied as a plain dictionary
+    ///     (same conversion rules as a `track` event's `properties`). They are
+    ///     attached at lower precedence than the reserved `event.*` fields, so
+    ///     they can never clobber the taxonomy.
+    func trackScreenView(name: String, screenClass: String?, screenId: String?, category: String?, properties: [String: Any]?)
 }
 
 extension Observe {
     public func trackScreenView(name: String) {
-        trackScreenView(name: name, screenClass: nil, screenId: nil, category: nil)
+        trackScreenView(name: name, screenClass: nil, screenId: nil, category: nil, properties: nil)
     }
 
     public func trackScreenView(name: String, category: String?) {
-        trackScreenView(name: name, screenClass: nil, screenId: nil, category: category)
+        trackScreenView(name: name, screenClass: nil, screenId: nil, category: category, properties: nil)
+    }
+
+    /// Convenience that omits the screen class/id. See the full overload for the
+    /// `properties` semantics.
+    public func trackScreenView(name: String, category: String? = nil, properties: [String: Any]?) {
+        trackScreenView(name: name, screenClass: nil, screenId: nil, category: category, properties: properties)
+    }
+
+    /// Convenience overload without `properties`, preserving the prior call shape.
+    public func trackScreenView(name: String, screenClass: String?, screenId: String?, category: String?) {
+        trackScreenView(name: name, screenClass: screenClass, screenId: screenId, category: category, properties: nil)
     }
 }
 
@@ -78,6 +94,18 @@ extension LogsApi {
     public func recordLog(message: String, severity: Severity, spanContext: SpanContext? = nil) {
         recordLog(message: message, severity: severity, attributes: [:], spanContext: spanContext)
     }
+
+    /// Record a log whose attributes are supplied as a plain dictionary.
+    ///
+    /// Prefer this over ``recordLog(message:severity:attributes:spanContext:)``
+    /// for everyday use: pass native values (`String`, `Bool`, `Int`, `Double`,
+    /// arrays, nested dictionaries) and they are converted to OTel attributes with
+    /// the same rules as a `track` event's `properties`. The `attributes:`
+    /// (`AttributeValue`) overload remains available when you need precise OTel
+    /// typing. A distinct label keeps the two overloads unambiguous.
+    public func recordLog(message: String, severity: Severity, properties: [String: Any], spanContext: SpanContext? = nil) {
+        recordLog(message: message, severity: severity, attributes: properties.toOtelAttributes(), spanContext: spanContext)
+    }
 }
 
 public protocol TracesApi {
@@ -109,5 +137,22 @@ extension TracesApi {
     /// to the implementation's default. Conformers that can honor a specific kind override this.
     public func startSpan(name: String, attributes: [String : AttributeValue], spanKind: SpanKind) -> Span {
         startSpan(name: name, attributes: attributes)
+    }
+
+    /// Start a span whose attributes are supplied as a plain dictionary.
+    ///
+    /// Prefer this over ``startSpan(name:attributes:)`` for everyday use: pass
+    /// native values and they are converted to OTel attributes with the same
+    /// rules as a `track` event's `properties`. The `attributes:`
+    /// (`AttributeValue`) overload remains available when you need precise OTel
+    /// typing.
+    public func startSpan(name: String, properties: [String: Any]) -> Span {
+        startSpan(name: name, attributes: properties.toOtelAttributes())
+    }
+
+    /// Start a span with an explicit kind whose attributes are supplied as a
+    /// plain dictionary. See ``startSpan(name:properties:)``.
+    public func startSpan(name: String, properties: [String: Any], spanKind: SpanKind) -> Span {
+        startSpan(name: name, attributes: properties.toOtelAttributes(), spanKind: spanKind)
     }
 }

--- a/Sources/LaunchDarklyObservability/API/TrackEvent.swift
+++ b/Sources/LaunchDarklyObservability/API/TrackEvent.swift
@@ -4,7 +4,7 @@ import OpenTelemetryApi
 /// A custom analytics `track` event broadcast to in-process consumers such as Session Replay.
 ///
 /// Emitted by the single `track` emitter for every track path — `LDClient.track` (via the
-/// observability hook) and the manual ``LDObserve/track(key:data:metricValue:)`` API, including
+/// observability hook) and the manual ``LDObserve/track(key:properties:metricValue:)`` API, including
 /// standalone init without `LDClient`. Session Replay maps these to RRWeb `Custom` events tagged
 /// `"Track"`, mirroring the web SDK.
 public struct TrackEvent {

--- a/Sources/LaunchDarklyObservability/Bridge/AttributeConverter.swift
+++ b/Sources/LaunchDarklyObservability/Bridge/AttributeConverter.swift
@@ -7,15 +7,13 @@ import OpenTelemetryApi
 /// (`LDValue` bridged to Foundation), the manual `LDObserve` track/log/span
 /// APIs (`[String: Any]`), and the Obj-C / .NET MAUI bridge (`NSString`,
 /// `NSNumber`, `NSDictionary`, `NSArray`). `AttributeValue.init?(Any)` does not
-/// handle Foundation collection types, so this converter checks for
-/// `NSDictionary` / `NSArray` explicitly and recurses into nested structures.
+/// handle Foundation collection/number types, so this converter checks for
+/// `NSDictionary` / `NSArray` / `NSNumber` explicitly and recurses into nested
+/// structures. Anything else is handed to `AttributeValue.init?` so the
+/// representation choice stays OpenTelemetry's, not ours.
 ///
-/// Common Foundation reference types with a well-defined string form
-/// (`Date`, `URL`, `UUID`, `Data`) are always mapped to that form, independent
-/// of `stringifyUnknown`, so values bridged from Obj-C / .NET MAUI are never lost.
-///
-/// `stringifyUnknown` only controls what happens to values that have *no*
-/// meaningful representation (e.g. an arbitrary object):
+/// `stringifyUnknown` controls what happens to values OpenTelemetry cannot
+/// represent (e.g. a `Date`, which has no OTel attribute form):
 /// - `false` (default): drop the value, so it never appears as an attribute.
 /// - `true`: fall back to `.string(String(describing:))`.
 ///
@@ -23,8 +21,6 @@ import OpenTelemetryApi
 /// the `.null <-> NSNull` Foundation mapping — there is no OTel attribute form for
 /// null, and emitting a `"<null>"` string would be misleading.
 public enum AttributeConverter {
-
-    private static let iso8601Formatter = ISO8601DateFormatter()
 
     /// Converts a `[String: Any]` dictionary into `[String: AttributeValue]`,
     /// omitting any entries whose value cannot be represented.
@@ -49,9 +45,9 @@ public enum AttributeConverter {
     /// 5. `NSNumber`      → `.bool` / `.int` / `.double` based on `objCType`
     ///    (avoids Swift's special bridging that converts NSNumber(0/1) to Bool)
     /// 6. `String`        → `.string`
-    /// 7. Swift `Bool`/`Int`/`Double` → guaranteed fallback for non-bridged scalars
-    /// 8. `Date`/`URL`/`UUID`/`Data` → `.string` (well-defined form, always kept)
-    /// 9. Unrepresentable → `.string(String(describing:))` when `stringifyUnknown`, else `nil`
+    /// 7. Otherwise       → delegated to `AttributeValue(_:)`. Whatever OTel cannot
+    ///    represent (e.g. `Date`) becomes `.string(String(describing:))` when
+    ///    `stringifyUnknown` is set, else `nil`.
     public static func convertValue(_ value: Any, stringifyUnknown: Bool = false) -> AttributeValue? {
         // Already an attribute value, or a whole attribute set: use directly.
         if let attributeValue = value as? AttributeValue { return attributeValue }
@@ -94,23 +90,11 @@ public enum AttributeConverter {
 
         if let string = value as? String { return .string(string) }
 
-        // Explicit native Swift scalars as a guaranteed fallback, in case a value
-        // is not NSNumber-bridged. Kept after the NSNumber branch so a bridged
-        // NSNumber(0/1) keeps its numeric/bool identity rather than matching `Bool`.
-        if let boolValue = value as? Bool { return .bool(boolValue) }
-        if let intValue = value as? Int { return .int(intValue) }
-        if let doubleValue = value as? Double { return .double(doubleValue) }
-
-        // Common Foundation reference types with a well-defined string form.
-        // Handled explicitly (independent of `stringifyUnknown`) so values bridged
-        // from Obj-C / .NET MAUI aren't silently dropped.
-        if let date = value as? Date { return .string(iso8601Formatter.string(from: date)) }
-        if let url = value as? URL { return .string(url.absoluteString) }
-        if let uuid = value as? UUID { return .string(uuid.uuidString) }
-        if let data = value as? Data { return .string(data.base64EncodedString()) }
-
-        // Arbitrary objects with no meaningful form: stringify only when asked,
-        // otherwise drop.
+        // Delegate anything else to OpenTelemetry's own conversion rather than
+        // inventing a representation. It maps the remaining scalar/array types it
+        // supports and returns nil for everything it has no attribute form for
+        // (e.g. `Date`), which we then stringify only when asked, otherwise drop.
+        if let otelValue = AttributeValue(value) { return otelValue }
         return stringifyUnknown ? .string(String(describing: value)) : nil
     }
 }

--- a/Sources/LaunchDarklyObservability/Bridge/AttributeConverter.swift
+++ b/Sources/LaunchDarklyObservability/Bridge/AttributeConverter.swift
@@ -1,71 +1,116 @@
 import Foundation
 import OpenTelemetryApi
 
-/// Converts Foundation types (from Obj-C bridge) into OpenTelemetry `AttributeValue`.
+/// Converts Foundation / Swift values into OpenTelemetry `AttributeValue`s.
 ///
-/// Values arriving from a .NET MAUI / Obj-C bridge are Foundation types
-/// (`NSString`, `NSNumber`, `NSDictionary`, `NSArray`).
-/// `AttributeValue.init?(Any)` does not handle Foundation collection types,
-/// so this converter checks for `NSDictionary` / `NSArray` explicitly and
-/// recurses into nested structures.
+/// Values reach this converter from several sources: the LD `track` hook
+/// (`LDValue` bridged to Foundation), the manual `LDObserve` track/log/span
+/// APIs (`[String: Any]`), and the Obj-C / .NET MAUI bridge (`NSString`,
+/// `NSNumber`, `NSDictionary`, `NSArray`). `AttributeValue.init?(Any)` does not
+/// handle Foundation collection types, so this converter checks for
+/// `NSDictionary` / `NSArray` explicitly and recurses into nested structures.
+///
+/// Common Foundation reference types with a well-defined string form
+/// (`Date`, `URL`, `UUID`, `Data`) are always mapped to that form, independent
+/// of `stringifyUnknown`, so values bridged from Obj-C / .NET MAUI are never lost.
+///
+/// `stringifyUnknown` only controls what happens to values that have *no*
+/// meaningful representation (e.g. an arbitrary object):
+/// - `false` (default): drop the value, so it never appears as an attribute.
+/// - `true`: fall back to `.string(String(describing:))`.
+///
+/// `null` (`NSNull`) is always dropped regardless of `stringifyUnknown`, mirroring
+/// the `.null <-> NSNull` Foundation mapping — there is no OTel attribute form for
+/// null, and emitting a `"<null>"` string would be misleading.
 public enum AttributeConverter {
 
-    /// Converts a `[String: Any]` dictionary of Foundation values into
-    /// `[String: AttributeValue]`.
-    public static func convert(_ source: [String: Any]) -> [String: AttributeValue] {
+    private static let iso8601Formatter = ISO8601DateFormatter()
+
+    /// Converts a `[String: Any]` dictionary into `[String: AttributeValue]`,
+    /// omitting any entries whose value cannot be represented.
+    public static func convert(_ source: [String: Any], stringifyUnknown: Bool = false) -> [String: AttributeValue] {
         var result: [String: AttributeValue] = [:]
         for (key, value) in source {
-            result[key] = convertValue(value)
+            if let converted = convertValue(value, stringifyUnknown: stringifyUnknown) {
+                result[key] = converted
+            }
         }
         return result
     }
 
-    /// Converts a single Foundation value into an `AttributeValue`.
+    /// Converts a single value into an `AttributeValue`, or `nil` when it has no
+    /// representable form (and `stringifyUnknown` is `false`).
     ///
     /// Resolution order:
-    /// 1. `NSDictionary`  → `.set(AttributeSet(labels: …))` (recursive)
-    /// 2. `NSArray`       → `.array(AttributeArray(values: …))` (recursive)
-    /// 3. `NSNumber`      → `.bool` / `.int` / `.double` based on `objCType`
+    /// 1. `AttributeValue` / `[String: AttributeValue]` → used directly.
+    /// 2. `NSNull`        → dropped (no OTel null form).
+    /// 3. `NSDictionary`  → `.set(AttributeSet(labels: …))` (recursive)
+    /// 4. `NSArray`       → `.array(AttributeArray(values: …))` (recursive)
+    /// 5. `NSNumber`      → `.bool` / `.int` / `.double` based on `objCType`
     ///    (avoids Swift's special bridging that converts NSNumber(0/1) to Bool)
-    /// 4. `String`        → `.string`
-    /// 5. Fallback        → `.string(String(describing: value))`
-    public static func convertValue(_ value: Any) -> AttributeValue {
+    /// 6. `String`        → `.string`
+    /// 7. Swift `Bool`/`Int`/`Double` → guaranteed fallback for non-bridged scalars
+    /// 8. `Date`/`URL`/`UUID`/`Data` → `.string` (well-defined form, always kept)
+    /// 9. Unrepresentable → `.string(String(describing:))` when `stringifyUnknown`, else `nil`
+    public static func convertValue(_ value: Any, stringifyUnknown: Bool = false) -> AttributeValue? {
+        // Already an attribute value, or a whole attribute set: use directly.
+        if let attributeValue = value as? AttributeValue { return attributeValue }
+        if let labels = value as? [String: AttributeValue] {
+            return .set(AttributeSet(labels: labels))
+        }
+
+        // Explicit null has no OTel attribute form; drop it (matching the
+        // `.null <-> NSNull` Foundation mapping) rather than emitting "<null>".
+        if value is NSNull { return nil }
+
+        // Nested dictionary -> nested attribute set.
         if let nsDict = value as? NSDictionary {
             var labels: [String: AttributeValue] = [:]
-            for (key, val) in nsDict {
-                if let strKey = key as? String {
-                    labels[strKey] = convertValue(val)
+            for (rawKey, nestedValue) in nsDict {
+                if let key = rawKey as? String,
+                   let converted = convertValue(nestedValue, stringifyUnknown: stringifyUnknown) {
+                    labels[key] = converted
                 }
             }
             return .set(AttributeSet(labels: labels))
         }
 
-        if let nsArr = value as? NSArray {
-            var values: [AttributeValue] = []
-            for item in nsArr {
-                values.append(convertValue(item))
-            }
-            return .array(AttributeArray(values: values))
+        // Array -> attribute array, dropping elements that can't be represented.
+        if let nsArray = value as? NSArray {
+            return .array(AttributeArray(values: nsArray.compactMap { convertValue($0, stringifyUnknown: stringifyUnknown) }))
         }
 
-        // Handle NSNumber before AttributeValue.init?(Any) to avoid Swift's
-        // special Bool bridging: the runtime converts NSNumber(0) and NSNumber(1)
-        // to Bool regardless of the original numeric type.
-        if let nsNum = value as? NSNumber {
-            switch String(cString: nsNum.objCType) {
-            case "c", "B":
-                return .bool(nsNum.boolValue)
-            case "d", "f":
-                return .double(nsNum.doubleValue)
-            default:
-                return .int(nsNum.intValue)
+        // NSNumber covers values bridged from the Obj-C/pigeon bridge and, on
+        // Apple platforms, native Swift Bool/Int/Double (which bridge to NSNumber).
+        // objCType disambiguates bool vs numeric so an NSNumber(0/1) is not misread
+        // as a Bool (and vice versa).
+        if let number = value as? NSNumber {
+            switch String(cString: number.objCType) {
+            case "c", "B": return .bool(number.boolValue)
+            case "d", "f": return .double(number.doubleValue)
+            default: return .int(number.intValue)
             }
         }
 
-        if let s = value as? String {
-            return .string(s)
-        }
+        if let string = value as? String { return .string(string) }
 
-        return .string(String(describing: value))
+        // Explicit native Swift scalars as a guaranteed fallback, in case a value
+        // is not NSNumber-bridged. Kept after the NSNumber branch so a bridged
+        // NSNumber(0/1) keeps its numeric/bool identity rather than matching `Bool`.
+        if let boolValue = value as? Bool { return .bool(boolValue) }
+        if let intValue = value as? Int { return .int(intValue) }
+        if let doubleValue = value as? Double { return .double(doubleValue) }
+
+        // Common Foundation reference types with a well-defined string form.
+        // Handled explicitly (independent of `stringifyUnknown`) so values bridged
+        // from Obj-C / .NET MAUI aren't silently dropped.
+        if let date = value as? Date { return .string(iso8601Formatter.string(from: date)) }
+        if let url = value as? URL { return .string(url.absoluteString) }
+        if let uuid = value as? UUID { return .string(uuid.uuidString) }
+        if let data = value as? Data { return .string(data.base64EncodedString()) }
+
+        // Arbitrary objects with no meaningful form: stringify only when asked,
+        // otherwise drop.
+        return stringifyUnknown ? .string(String(describing: value)) : nil
     }
 }

--- a/Sources/LaunchDarklyObservability/Bridge/ObjcLDObserveBridge.swift
+++ b/Sources/LaunchDarklyObservability/Bridge/ObjcLDObserveBridge.swift
@@ -22,6 +22,15 @@ public final class ObjcLDObserveBridge: NSObject {
         return ObjcLogger(internalLogger: service.logClient, customerLogger: service.customerLogClient)
     }
 
+    /// Records a custom `track` event. Always broadcasts a Session Replay
+    /// `Track` timeline event and, when `analytics.trackEvents` is enabled, emits
+    /// the `track` span. `data` carries the optional event payload as a plain
+    /// dictionary (e.g. across the Flutter pigeon bridge).
+    @objc(trackWithKey:data:metricValue:)
+    public static func track(key: String, data: [String: Any]?, metricValue: NSNumber?) {
+        LDObserve.shared.track(key: key, data: data, metricValue: metricValue?.doubleValue)
+    }
+
     @objc(recordErrorWithMessage:cause:)
     public static func recordError(message: String, cause: String?) {
         let error = NSError(

--- a/Sources/LaunchDarklyObservability/Bridge/ObjcLDObserveBridge.swift
+++ b/Sources/LaunchDarklyObservability/Bridge/ObjcLDObserveBridge.swift
@@ -25,10 +25,30 @@ public final class ObjcLDObserveBridge: NSObject {
     /// Records a custom `track` event. Always broadcasts a Session Replay
     /// `Track` timeline event and, when `analytics.trackEvents` is enabled, emits
     /// the `track` span. `data` carries the optional event payload as a plain
-    /// dictionary (e.g. across the Flutter pigeon bridge).
-    @objc(trackWithKey:data:metricValue:)
-    public static func track(key: String, data: [String: Any]?, metricValue: NSNumber?) {
-        LDObserve.shared.track(key: key, data: data, metricValue: metricValue?.doubleValue)
+    /// dictionary (e.g. across the Flutter pigeon bridge). `contextKeys` carries
+    /// the evaluation context's kind -> key pairs; when supplied they annotate
+    /// the `track` span (not the Session Replay `Track` payload), so hosts whose
+    /// LaunchDarkly client lives outside this SDK (e.g. Flutter) can attribute
+    /// the span to the same context the web SDK records.
+    @objc(trackWithKey:data:metricValue:contextKeys:)
+    public static func track(key: String, data: [String: Any]?, metricValue: NSNumber?, contextKeys: [String: String]?) {
+        guard let contextKeys, !contextKeys.isEmpty,
+              let service = LDObserve.shared.client as? ObservabilityService else {
+            // No explicit context (or no live service): fall back to the public
+            // path, which uses the cached identify context for the span.
+            LDObserve.shared.track(key: key, data: data, metricValue: metricValue?.doubleValue)
+            return
+        }
+        var contextKeyAttributes: [String: AttributeValue] = [:]
+        for (kind, value) in contextKeys {
+            contextKeyAttributes[kind] = .string(value)
+        }
+        service.track(
+            name: key,
+            metricValue: metricValue?.doubleValue,
+            attributes: data.map { AttributeConverter.convert($0) } ?? [:],
+            contextKeyAttributes: contextKeyAttributes
+        )
     }
 
     @objc(recordErrorWithMessage:cause:)

--- a/Sources/LaunchDarklyObservability/Bridge/ObjcLDObserveBridge.swift
+++ b/Sources/LaunchDarklyObservability/Bridge/ObjcLDObserveBridge.swift
@@ -36,7 +36,7 @@ public final class ObjcLDObserveBridge: NSObject {
               let service = LDObserve.shared.client as? ObservabilityService else {
             // No explicit context (or no live service): fall back to the public
             // path, which uses the cached identify context for the span.
-            LDObserve.shared.track(key: key, data: data, metricValue: metricValue?.doubleValue)
+            LDObserve.shared.track(key: key, properties: data, metricValue: metricValue?.doubleValue)
             return
         }
         var contextKeyAttributes: [String: AttributeValue] = [:]

--- a/Sources/LaunchDarklyObservability/Bridge/ObjcLDObserveBridge.swift
+++ b/Sources/LaunchDarklyObservability/Bridge/ObjcLDObserveBridge.swift
@@ -46,7 +46,7 @@ public final class ObjcLDObserveBridge: NSObject {
         service.track(
             name: key,
             metricValue: metricValue?.doubleValue,
-            attributes: data.map { AttributeConverter.convert($0) } ?? [:],
+            attributes: data?.toOtelAttributes() ?? [:],
             contextKeyAttributes: contextKeyAttributes
         )
     }

--- a/Sources/LaunchDarklyObservability/Bridge/ObjcSpanBuilder.swift
+++ b/Sources/LaunchDarklyObservability/Bridge/ObjcSpanBuilder.swift
@@ -43,7 +43,8 @@ public final class ObjcSpanBuilder: NSObject {
 
     @objc(setAttributeWithKey:value:)
     public func setAttribute(key: String, value: NSObject) {
-        span.setAttribute(key: key, value: AttributeConverter.convertValue(value))
+        guard let converted = AttributeConverter.convertValue(value) else { return }
+        span.setAttribute(key: key, value: converted)
     }
 
     @objc(setAttributes:)

--- a/Sources/LaunchDarklyObservability/Bridge/OtelAttributes.swift
+++ b/Sources/LaunchDarklyObservability/Bridge/OtelAttributes.swift
@@ -42,8 +42,10 @@ extension Dictionary where Key == String, Value == Any {
             return .array(AttributeArray(values: nsArray.compactMap { attributeValue(from: $0) }))
         }
 
-        // Match the NSNumber handling used for spans/logs so a numeric
-        // NSNumber(0/1) is not misread as a Bool (and vice versa).
+        // NSNumber covers values bridged from the Obj-C/pigeon bridge and, on
+        // Apple platforms, native Swift Bool/Int/Double (which bridge to NSNumber).
+        // objCType disambiguates bool vs numeric so an NSNumber(0/1) is not misread
+        // as a Bool (and vice versa).
         if let number = value as? NSNumber {
             switch String(cString: number.objCType) {
             case "c", "B": return .bool(number.boolValue)
@@ -53,6 +55,13 @@ extension Dictionary where Key == String, Value == Any {
         }
 
         if let string = value as? String { return .string(string) }
+
+        // Explicit native Swift scalars as a guaranteed fallback, in case a value
+        // is not NSNumber-bridged. Kept after the NSNumber branch so a bridged
+        // NSNumber(0/1) keeps its numeric/bool identity rather than matching `Bool`.
+        if let boolValue = value as? Bool { return .bool(boolValue) }
+        if let intValue = value as? Int { return .int(intValue) }
+        if let doubleValue = value as? Double { return .double(doubleValue) }
 
         // Date, arbitrary objects, etc.: dropped rather than stringified.
         return nil

--- a/Sources/LaunchDarklyObservability/Bridge/OtelAttributes.swift
+++ b/Sources/LaunchDarklyObservability/Bridge/OtelAttributes.swift
@@ -1,0 +1,60 @@
+import Foundation
+import OpenTelemetryApi
+
+extension Dictionary where Key == String, Value == Any {
+    /// Converts a `track` event's `data` payload into OTel attributes.
+    ///
+    /// Structure is preserved: scalars map to scalar values, nested dictionaries
+    /// to `.set`, arrays to `.array`, and an already-built `AttributeValue` (or a
+    /// whole `[String: AttributeValue]` set) is used as-is. Any value that has no
+    /// meaningful attribute form (e.g. a `Date` or an arbitrary object) is
+    /// skipped — never stringified.
+    func toOtelAttributes() -> [String: AttributeValue] {
+        var result: [String: AttributeValue] = [:]
+        for (key, value) in self {
+            if let converted = Self.attributeValue(from: value) {
+                result[key] = converted
+            }
+        }
+        return result
+    }
+
+    private static func attributeValue(from value: Any) -> AttributeValue? {
+        // Already an attribute value, or a whole attribute set: use directly.
+        if let attributeValue = value as? AttributeValue { return attributeValue }
+        if let labels = value as? [String: AttributeValue] {
+            return .set(AttributeSet(labels: labels))
+        }
+
+        // Nested dictionary -> nested attribute set.
+        if let nsDict = value as? NSDictionary {
+            var labels: [String: AttributeValue] = [:]
+            for (rawKey, nestedValue) in nsDict {
+                if let key = rawKey as? String, let converted = attributeValue(from: nestedValue) {
+                    labels[key] = converted
+                }
+            }
+            return .set(AttributeSet(labels: labels))
+        }
+
+        // Array -> attribute array, dropping elements that can't be represented.
+        if let nsArray = value as? NSArray {
+            return .array(AttributeArray(values: nsArray.compactMap { attributeValue(from: $0) }))
+        }
+
+        // Match the NSNumber handling used for spans/logs so a numeric
+        // NSNumber(0/1) is not misread as a Bool (and vice versa).
+        if let number = value as? NSNumber {
+            switch String(cString: number.objCType) {
+            case "c", "B": return .bool(number.boolValue)
+            case "d", "f": return .double(number.doubleValue)
+            default: return .int(number.intValue)
+            }
+        }
+
+        if let string = value as? String { return .string(string) }
+
+        // Date, arbitrary objects, etc.: dropped rather than stringified.
+        return nil
+    }
+}

--- a/Sources/LaunchDarklyObservability/Bridge/OtelAttributes.swift
+++ b/Sources/LaunchDarklyObservability/Bridge/OtelAttributes.swift
@@ -2,68 +2,13 @@ import Foundation
 import OpenTelemetryApi
 
 extension Dictionary where Key == String, Value == Any {
-    /// Converts a `track` event's `data` payload into OTel attributes.
+    /// Converts a `track`/log/span `properties` payload into OTel attributes.
     ///
-    /// Structure is preserved: scalars map to scalar values, nested dictionaries
-    /// to `.set`, arrays to `.array`, and an already-built `AttributeValue` (or a
-    /// whole `[String: AttributeValue]` set) is used as-is. Any value that has no
-    /// meaningful attribute form (e.g. a `Date` or an arbitrary object) is
-    /// skipped — never stringified.
+    /// Structure is preserved (scalars, nested dictionaries, arrays, and
+    /// pre-built `AttributeValue`s). Values with no attribute form (e.g. a `Date`
+    /// or `null`) are dropped rather than stringified. Thin convenience wrapper
+    /// over ``AttributeConverter/convert(_:stringifyUnknown:)``.
     func toOtelAttributes() -> [String: AttributeValue] {
-        var result: [String: AttributeValue] = [:]
-        for (key, value) in self {
-            if let converted = Self.attributeValue(from: value) {
-                result[key] = converted
-            }
-        }
-        return result
-    }
-
-    private static func attributeValue(from value: Any) -> AttributeValue? {
-        // Already an attribute value, or a whole attribute set: use directly.
-        if let attributeValue = value as? AttributeValue { return attributeValue }
-        if let labels = value as? [String: AttributeValue] {
-            return .set(AttributeSet(labels: labels))
-        }
-
-        // Nested dictionary -> nested attribute set.
-        if let nsDict = value as? NSDictionary {
-            var labels: [String: AttributeValue] = [:]
-            for (rawKey, nestedValue) in nsDict {
-                if let key = rawKey as? String, let converted = attributeValue(from: nestedValue) {
-                    labels[key] = converted
-                }
-            }
-            return .set(AttributeSet(labels: labels))
-        }
-
-        // Array -> attribute array, dropping elements that can't be represented.
-        if let nsArray = value as? NSArray {
-            return .array(AttributeArray(values: nsArray.compactMap { attributeValue(from: $0) }))
-        }
-
-        // NSNumber covers values bridged from the Obj-C/pigeon bridge and, on
-        // Apple platforms, native Swift Bool/Int/Double (which bridge to NSNumber).
-        // objCType disambiguates bool vs numeric so an NSNumber(0/1) is not misread
-        // as a Bool (and vice versa).
-        if let number = value as? NSNumber {
-            switch String(cString: number.objCType) {
-            case "c", "B": return .bool(number.boolValue)
-            case "d", "f": return .double(number.doubleValue)
-            default: return .int(number.intValue)
-            }
-        }
-
-        if let string = value as? String { return .string(string) }
-
-        // Explicit native Swift scalars as a guaranteed fallback, in case a value
-        // is not NSNumber-bridged. Kept after the NSNumber branch so a bridged
-        // NSNumber(0/1) keeps its numeric/bool identity rather than matching `Bool`.
-        if let boolValue = value as? Bool { return .bool(boolValue) }
-        if let intValue = value as? Int { return .int(intValue) }
-        if let doubleValue = value as? Double { return .double(doubleValue) }
-
-        // Date, arbitrary objects, etc.: dropped rather than stringified.
-        return nil
+        AttributeConverter.convert(self, stringifyUnknown: false)
     }
 }

--- a/Sources/LaunchDarklyObservability/Client/NoOpObservabilityService.swift
+++ b/Sources/LaunchDarklyObservability/Client/NoOpObservabilityService.swift
@@ -22,9 +22,9 @@ final class NoOpObservabilityService: Observe {
         NoOpTracer().startSpan(name: name, attributes: attributes)
     }
 
-    func track(key: String, data: [String: Any]?, metricValue: Double?) {}
+    func track(key: String, properties: [String: Any]?, metricValue: Double?) {}
 
-    func trackScreenView(name: String, screenClass: String?, screenId: String?, category: String?) {}
+    func trackScreenView(name: String, screenClass: String?, screenId: String?, category: String?, properties: [String: Any]?) {}
 }
 
 extension NoOpObservabilityService {

--- a/Sources/LaunchDarklyObservability/Client/NoOpObservabilityService.swift
+++ b/Sources/LaunchDarklyObservability/Client/NoOpObservabilityService.swift
@@ -22,7 +22,7 @@ final class NoOpObservabilityService: Observe {
         NoOpTracer().startSpan(name: name, attributes: attributes)
     }
 
-    func track(key: String, data: LDValue?, metricValue: Double?) {}
+    func track(key: String, data: [String: Any]?, metricValue: Double?) {}
 
     func trackScreenView(name: String, screenClass: String?, screenId: String?, category: String?) {}
 }

--- a/Sources/LaunchDarklyObservability/Client/ObservabilityService.swift
+++ b/Sources/LaunchDarklyObservability/Client/ObservabilityService.swift
@@ -436,7 +436,7 @@ extension ObservabilityService: Observe {
     func track(key: String, data: [String: Any]?, metricValue: Double?) {
         track(name: key,
               metricValue: metricValue,
-              attributes: data.map { AttributeConverter.convert($0) } ?? [:],
+              attributes: data?.toOtelAttributes() ?? [:],
               contextKeyAttributes: nil)
     }
 
@@ -469,6 +469,7 @@ extension ObservabilityService: TrackEmitting {
         )
 
         guard options.analytics.trackEvents.isEnabled else { return }
+        guard options.tracesApi.includeSpans else { return }
 
         // Apply in increasing precedence so event identity can never be clobbered: user-supplied
         // track data first, then context keys, then the reserved key/value attributes last.
@@ -485,8 +486,14 @@ extension ObservabilityService: TrackEmitting {
             spanAttributes["value"] = .double(metricValue)
         }
 
-        let span = tracer.startSpan(name: SemanticConvention.trackSpanName, attributes: spanAttributes)
-        span.end()
+        // `track` events are modeled as CONSUMER spans (an incoming domain event)
+        // rather than INTERNAL. Built via the decorator so the span kind can be set.
+        let builder = tracerDecorator.spanBuilder(spanName: SemanticConvention.trackSpanName)
+        builder.setSpanKind(spanKind: .consumer)
+        for (key, value) in spanAttributes {
+            builder.setAttribute(key: key, value: value)
+        }
+        builder.startSpan().end()
     }
 
     /// Single funnel for screen changes. Both the automatic

--- a/Sources/LaunchDarklyObservability/Client/ObservabilityService.swift
+++ b/Sources/LaunchDarklyObservability/Client/ObservabilityService.swift
@@ -433,16 +433,22 @@ extension ObservabilityService: Observe {
         tracer.startSpan(name: name, attributes: attributes)
     }
 
-    func track(key: String, data: [String: Any]?, metricValue: Double?) {
+    func track(key: String, properties: [String: Any]?, metricValue: Double?) {
         track(name: key,
               metricValue: metricValue,
-              attributes: data?.toOtelAttributes() ?? [:],
+              attributes: properties?.toOtelAttributes() ?? [:],
               contextKeyAttributes: nil)
     }
 
-    func trackScreenView(name: String, screenClass: String?, screenId: String?, category: String?) {
+    func trackScreenView(name: String, screenClass: String?, screenId: String?, category: String?, properties: [String: Any]?) {
         emitScreenView(
-            ScreenView(name: name, screenClass: screenClass, screenId: screenId, category: category)
+            ScreenView(
+                name: name,
+                screenClass: screenClass,
+                screenId: screenId,
+                category: category,
+                attributes: properties?.toOtelAttributes() ?? [:]
+            )
         )
     }
 }
@@ -525,9 +531,13 @@ extension ObservabilityService: TrackEmitting {
         // Only the analytics span is gated by the screenViews flag.
         guard options.analytics.screenViews.isEnabled else { return }
 
-        // Apply in increasing precedence so the screen-view taxonomy can never be clobbered: identify
-        // context keys first, then the reserved `event.*` fields last (matching the track path).
+        // Apply in increasing precedence so the screen-view taxonomy can never be clobbered: caller
+        // properties first, then identify context keys, then the reserved `event.*` fields last
+        // (matching the track path).
         var spanAttributes: [String: AttributeValue] = [:]
+        for (k, v) in screen.attributes {
+            spanAttributes[k] = v
+        }
         for (k, v) in cachedContextKeyAttributes {
             spanAttributes[k] = v
         }

--- a/Sources/LaunchDarklyObservability/Client/ObservabilityService.swift
+++ b/Sources/LaunchDarklyObservability/Client/ObservabilityService.swift
@@ -433,10 +433,10 @@ extension ObservabilityService: Observe {
         tracer.startSpan(name: name, attributes: attributes)
     }
 
-    func track(key: String, data: LDValue?, metricValue: Double?) {
+    func track(key: String, data: [String: Any]?, metricValue: Double?) {
         track(name: key,
               metricValue: metricValue,
-              attributes: data?.toAttributes() ?? [:],
+              attributes: data.map { AttributeConverter.convert($0) } ?? [:],
               contextKeyAttributes: nil)
     }
 

--- a/Sources/LaunchDarklyObservability/Plugin/LDValue+Attributes.swift
+++ b/Sources/LaunchDarklyObservability/Plugin/LDValue+Attributes.swift
@@ -12,8 +12,12 @@ extension LDValue {
     /// Foundation, so scalar/array/object handling stays in one place. Only
     /// object payloads have key/value members; scalar and array payloads map to
     /// an empty dictionary.
+    ///
+    /// Uses the default `stringifyUnknown: false`, so values without an attribute
+    /// form (e.g. `null`) are dropped — keeping the `LDClient.track` hook path
+    /// identical to the manual `LDObserve.track` path.
     func toAttributes() -> [String: AttributeValue] {
         guard case .object = self else { return [:] }
-        return AttributeConverter.convert((toFoundation() as? [String: Any]) ?? [:])
+        return AttributeConverter.convert((toFoundation() as? [String: Any]) ?? [:], stringifyUnknown: false)
     }
 }

--- a/Sources/LaunchDarklyObservability/UIInteractions/ScreenView/ScreenView.swift
+++ b/Sources/LaunchDarklyObservability/UIInteractions/ScreenView/ScreenView.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OpenTelemetryApi
 
 /// A single screen appearance, mapped to the taxonomy `screen_view` event.
 ///
@@ -13,6 +14,10 @@ struct ScreenView: Equatable {
     let screenId: String?
     /// Screen group, e.g. `Onboarding`. Maps to `event.category`.
     let category: String?
+    /// Optional caller-supplied attributes attached to the `screen_view` span,
+    /// applied at lower precedence than the reserved `event.*` fields so they can
+    /// never clobber the taxonomy. Empty for automatically captured screens.
+    let attributes: [String: AttributeValue]
     /// Capture time.
     let timestamp: TimeInterval
 
@@ -20,11 +25,13 @@ struct ScreenView: Equatable {
          screenClass: String? = nil,
          screenId: String? = nil,
          category: String? = nil,
+         attributes: [String: AttributeValue] = [:],
          timestamp: TimeInterval = Date().timeIntervalSince1970) {
         self.name = name
         self.screenClass = screenClass
         self.screenId = screenId
         self.category = category
+        self.attributes = attributes
         self.timestamp = timestamp
     }
 }

--- a/TestApp/Sources/MainMenuView.swift
+++ b/TestApp/Sources/MainMenuView.swift
@@ -262,6 +262,8 @@ struct MainMenuView: View {
             HStack {
                 Button("Track Screen View") { viewModel.trackScreenView() }
                     .buttonStyle(.borderedProminent)
+                Button("Track (Nested)") { viewModel.trackNested() }
+                    .buttonStyle(.borderedProminent)
             }
 
             Text("Error")

--- a/TestApp/Sources/MainMenuViewModel.swift
+++ b/TestApp/Sources/MainMenuViewModel.swift
@@ -138,7 +138,7 @@ final class MainMenuViewModel: ObservableObject {
                 "test-string": "ios",
                 "test-true": true,
                 "test-false": false,
-                "test-integer": .number(42),
+                "test-integer": 42,
                 "test-double": 3.14
             ]
 		)

--- a/TestApp/Sources/MainMenuViewModel.swift
+++ b/TestApp/Sources/MainMenuViewModel.swift
@@ -105,7 +105,7 @@ final class MainMenuViewModel: ObservableObject {
 			message: "logs-button-pressed",
 			severity: .info,
 			attributes: [
-				"test-string": .string("maui"),
+				"test-string": .string("swift"),
 				"test-true": .bool(true),
 				"test-false": .bool(false),
 				"test-integer": .int(42),
@@ -119,7 +119,7 @@ final class MainMenuViewModel: ObservableObject {
 	func trackViaLDClient() {
 		// Records a track span automatically via the Observability afterTrack hook.
 		LDClient.get()?.track(
-            key: "track-via-ld-observe",
+            key: "track-via-ld-client",
             data: [
                 "test-string": "ios",
                 "test-true": true,
@@ -139,7 +139,9 @@ final class MainMenuViewModel: ObservableObject {
                 "test-true": true,
                 "test-false": false,
                 "test-integer": 42,
-                "test-double": 3.14
+                "test-double": 3.14,
+                "test-swiftmap": ["test-string": "val"],
+                "test-AttributeValue": AttributeValue.set(.init(labels: ["string": .string("swift")]))
             ]
 		)
 	}

--- a/TestApp/Sources/MainMenuViewModel.swift
+++ b/TestApp/Sources/MainMenuViewModel.swift
@@ -144,6 +144,25 @@ final class MainMenuViewModel: ObservableObject {
 		)
 	}
 
+	func trackNested() {
+		// A nested `track` payload following the Segment "Checkout Started"
+		// example from analytics-taxonomy.md (§4.2): scalar fields plus a
+		// `products` array of line-item objects.
+		LDObserve.shared.track(
+			key: "Checkout Started",
+			data: [
+				"name": "Checkout Started",
+				"order_id": "ord_5521",
+				"value": 72.0,
+				"currency": "USD",
+				"products": [
+					["product_id": "SKU-1234", "quantity": 2, "price": 24.0],
+					["product_id": "SKU-9876", "quantity": 1, "price": 24.0]
+				]
+			]
+		)
+	}
+
 	func trackScreenView() {
 		// Records a screen_view span manually; previous_screen is resolved through
 		// the same shared screen stack used by automatic capture.

--- a/TestApp/Sources/MainMenuViewModel.swift
+++ b/TestApp/Sources/MainMenuViewModel.swift
@@ -109,6 +109,7 @@ final class MainMenuViewModel: ObservableObject {
 				"test-true": true,
 				"test-false": false,
 				"test-integer": 42,
+				"test-long": 9_000_000_000,
 				"test-double": 3.14,
 				"test-array": [3.14],
 				"test-nested": ["array": [1]]
@@ -125,7 +126,8 @@ final class MainMenuViewModel: ObservableObject {
                 "test-true": true,
                 "test-false": false,
                 "test-integer": .number(42),
-                "test-double": 3.14
+                "test-double": 3.14,
+                "test-long-number": .number(9_000_000_000_123),
             ]
         )
 	}
@@ -139,6 +141,9 @@ final class MainMenuViewModel: ObservableObject {
                 "test-true": true,
                 "test-false": false,
                 "test-integer": 42,
+                // A 64-bit value beyond Int32 range (e.g. epoch nanoseconds),
+                // demonstrating that long integers survive conversion.
+                "test-long": 9_000_000_000_123,
                 "test-double": 3.14,
                 "test-swiftmap": ["test-string": "val"]
             ]

--- a/TestApp/Sources/MainMenuViewModel.swift
+++ b/TestApp/Sources/MainMenuViewModel.swift
@@ -25,8 +25,8 @@ final class MainMenuViewModel: ObservableObject {
 
 	func triggerNestedSpans() {
 		Task {
-			let span0 = LDObserve.shared.startSpan(name: "NestedSpan", attributes: ["test-true": .bool(true),
-                                                                                    "test-double": .double(3.14)])
+			let span0 = LDObserve.shared.startSpan(name: "NestedSpan", properties: ["test-true": true,
+                                                                                    "test-double": 3.14])
 			await OpenTelemetry.instance.contextProvider.withActiveSpan(span0) {
 				let span1 = LDObserve.shared.startSpan(name: "NestedSpan1", attributes: [:])
 				await OpenTelemetry.instance.contextProvider.withActiveSpan(span1) {
@@ -84,7 +84,7 @@ final class MainMenuViewModel: ObservableObject {
 	func recordLogWithContext() {
 		let span = LDObserve.shared.startSpan(
 			name: "log-context-demo",
-			attributes: ["demo": .string("log-with-context")]
+			properties: ["demo": "log-with-context"]
 		)
 		let capturedContext = span.context
 		span.end()
@@ -94,7 +94,7 @@ final class MainMenuViewModel: ObservableObject {
 			LDObserve.shared.recordLog(
 				message: "Log with span context",
 				severity: .warn,
-				attributes: ["source": .string("detached-queue-demo")],
+				properties: ["source": "detached-queue-demo"],
 				spanContext: capturedContext
 			)
 		}
@@ -104,14 +104,14 @@ final class MainMenuViewModel: ObservableObject {
 		LDObserve.shared.recordLog(
 			message: "logs-button-pressed",
 			severity: .info,
-			attributes: [
-				"test-string": .string("swift"),
-				"test-true": .bool(true),
-				"test-false": .bool(false),
-				"test-integer": .int(42),
-				"test-double": .double(3.14),
-				"test-array": .array(.init(values: [.double(3.14)])),
-				"test-nested": .set(.init(labels: ["array": .array(.init(values: [.int(1)]))]))
+			properties: [
+				"test-string": "swift",
+				"test-true": true,
+				"test-false": false,
+				"test-integer": 42,
+				"test-double": 3.14,
+				"test-array": [3.14],
+				"test-nested": ["array": [1]]
 			]
 		)
 	}
@@ -134,14 +134,13 @@ final class MainMenuViewModel: ObservableObject {
 		// Records a track span directly through the Observability API.
 		LDObserve.shared.track(
 			key: "track-via-ld-observe",
-            data: [
+            properties: [
                 "test-string": "ios",
                 "test-true": true,
                 "test-false": false,
                 "test-integer": 42,
                 "test-double": 3.14,
-                "test-swiftmap": ["test-string": "val"],
-                "test-AttributeValue": AttributeValue.set(.init(labels: ["string": .string("swift")]))
+                "test-swiftmap": ["test-string": "val"]
             ]
 		)
 	}
@@ -151,8 +150,8 @@ final class MainMenuViewModel: ObservableObject {
 		// example from analytics-taxonomy.md (§4.2): scalar fields plus a
 		// `products` array of line-item objects.
 		LDObserve.shared.track(
-			key: "Checkout Started",
-			data: [
+			key: "checkout-started",
+			properties: [
 				"name": "Checkout Started",
 				"order_id": "ord_5521",
 				"value": 72.0,
@@ -173,7 +172,11 @@ final class MainMenuViewModel: ObservableObject {
 			name: "Manual Demo Screen \(screenViewCounter)",
 			screenClass: "MainMenuView",
 			screenId: "main-menu-demo-\(screenViewCounter)",
-			category: "Demo"
+			category: "Demo",
+			properties: [
+				"source": "manual-demo",
+				"index": screenViewCounter
+			]
 		)
 	}
 

--- a/Tests/ObservabilityTests/Bridge/AttributeConverterTests.swift
+++ b/Tests/ObservabilityTests/Bridge/AttributeConverterTests.swift
@@ -31,13 +31,72 @@ struct AttributeConverterTests {
         #expect(result == .double(3.14))
     }
 
-    // MARK: - Unsupported / fallback
+    // MARK: - Foundation reference types (always represented)
 
-    @Test("falls back to string for unsupported types")
-    func unsupportedFallback() {
+    @Test("converts Date to ISO8601 string")
+    func dateValue() {
         let date = Date(timeIntervalSince1970: 0)
         let result = AttributeConverter.convertValue(date)
-        #expect(result == .string(String(describing: date)))
+        #expect(result == .string(ISO8601DateFormatter().string(from: date)))
+    }
+
+    @Test("converts URL to absolute string")
+    func urlValue() {
+        let url = URL(string: "https://example.com/path?q=1")!
+        let result = AttributeConverter.convertValue(url)
+        #expect(result == .string("https://example.com/path?q=1"))
+    }
+
+    @Test("converts UUID to uuidString")
+    func uuidValue() {
+        let uuid = UUID()
+        let result = AttributeConverter.convertValue(uuid)
+        #expect(result == .string(uuid.uuidString))
+    }
+
+    @Test("converts Data to base64 string")
+    func dataValue() {
+        let data = Data([0x01, 0x02, 0x03])
+        let result = AttributeConverter.convertValue(data)
+        #expect(result == .string(data.base64EncodedString()))
+    }
+
+    // MARK: - Unsupported / fallback
+
+    private final class Unrepresentable: NSObject {
+        override var description: String { "unrepresentable" }
+    }
+
+    @Test("drops unsupported types by default")
+    func unsupportedDroppedByDefault() {
+        #expect(AttributeConverter.convertValue(Unrepresentable()) == nil)
+    }
+
+    @Test("stringifies unsupported types when requested")
+    func unsupportedStringifiedWhenRequested() {
+        let result = AttributeConverter.convertValue(Unrepresentable(), stringifyUnknown: true)
+        #expect(result == .string("unrepresentable"))
+    }
+
+    // MARK: - Null
+
+    @Test("drops NSNull regardless of stringifyUnknown")
+    func nullAlwaysDropped() {
+        #expect(AttributeConverter.convertValue(NSNull()) == nil)
+        #expect(AttributeConverter.convertValue(NSNull(), stringifyUnknown: true) == nil)
+    }
+
+    @Test("drops null entries and array elements")
+    func nullDroppedInCollections() {
+        let source: [String: Any] = [
+            "kept": "value",
+            "dropped": NSNull(),
+            "list": [NSNumber(value: 1), NSNull(), NSNumber(value: 2)] as NSArray
+        ]
+        let result = AttributeConverter.convert(source)
+        #expect(result["kept"] == .string("value"))
+        #expect(result["dropped"] == nil)
+        #expect(result["list"] == .array(AttributeArray(values: [.int(1), .int(2)])))
     }
 
     // MARK: - NSDictionary (nested)

--- a/Tests/ObservabilityTests/Bridge/AttributeConverterTests.swift
+++ b/Tests/ObservabilityTests/Bridge/AttributeConverterTests.swift
@@ -25,54 +25,36 @@ struct AttributeConverterTests {
         #expect(result == .int(42))
     }
 
+    @Test("preserves 64-bit integers beyond Int32 range")
+    func preservesLong() {
+        // > Int32.max (2_147_483_647): must not be truncated to 32 bits.
+        let big = 9_000_000_000
+        #expect(AttributeConverter.convertValue(big) == .int(big))
+        // Same value arriving as a bridged NSNumber (objCType "q").
+        #expect(AttributeConverter.convertValue(NSNumber(value: Int64(big))) == .int(big))
+    }
+
     @Test("converts Double value")
     func doubleValue() {
         let result = AttributeConverter.convertValue(3.14)
         #expect(result == .double(3.14))
     }
 
-    // MARK: - Foundation reference types (always represented)
-
-    @Test("converts Date to ISO8601 string")
-    func dateValue() {
-        let date = Date(timeIntervalSince1970: 0)
-        let result = AttributeConverter.convertValue(date)
-        #expect(result == .string(ISO8601DateFormatter().string(from: date)))
-    }
-
-    @Test("converts URL to absolute string")
-    func urlValue() {
-        let url = URL(string: "https://example.com/path?q=1")!
-        let result = AttributeConverter.convertValue(url)
-        #expect(result == .string("https://example.com/path?q=1"))
-    }
-
-    @Test("converts UUID to uuidString")
-    func uuidValue() {
-        let uuid = UUID()
-        let result = AttributeConverter.convertValue(uuid)
-        #expect(result == .string(uuid.uuidString))
-    }
-
-    @Test("converts Data to base64 string")
-    func dataValue() {
-        let data = Data([0x01, 0x02, 0x03])
-        let result = AttributeConverter.convertValue(data)
-        #expect(result == .string(data.base64EncodedString()))
-    }
-
-    // MARK: - Unsupported / fallback
+    // MARK: - Unsupported / fallback (delegated to OpenTelemetry)
 
     private final class Unrepresentable: NSObject {
         override var description: String { "unrepresentable" }
     }
 
-    @Test("drops unsupported types by default")
+    @Test("drops values OpenTelemetry cannot represent by default")
     func unsupportedDroppedByDefault() {
+        // `Date` has no OTel attribute form, so OTel returns nil and we drop it
+        // rather than inventing a string format.
+        #expect(AttributeConverter.convertValue(Date(timeIntervalSince1970: 0)) == nil)
         #expect(AttributeConverter.convertValue(Unrepresentable()) == nil)
     }
 
-    @Test("stringifies unsupported types when requested")
+    @Test("stringifies unrepresentable values when requested")
     func unsupportedStringifiedWhenRequested() {
         let result = AttributeConverter.convertValue(Unrepresentable(), stringifyUnknown: true)
         #expect(result == .string("unrepresentable"))

--- a/Tests/ObservabilityTests/Bridge/OtelAttributesTests.swift
+++ b/Tests/ObservabilityTests/Bridge/OtelAttributesTests.swift
@@ -1,0 +1,208 @@
+import Foundation
+import Testing
+import OpenTelemetryApi
+@testable import LaunchDarklyObservability
+
+/// Exercises the `[String: Any].toOtelAttributes()` mapping used by the `track`
+/// paths (`ObservabilityService.track` / `ObjcLDObserveBridge.track`).
+///
+/// Scalars convert to scalar values, nested dictionaries to `.set`, arrays to
+/// `.array`, and already-built attribute values are used as-is. Values with no
+/// meaningful attribute form (dates, arbitrary objects) are dropped rather than
+/// stringified.
+struct OtelAttributesTests {
+
+    // MARK: - Supported scalars
+
+    @Test("converts bool / number / string members")
+    func convertsScalars() {
+        let source: [String: Any] = [
+            "flag": true,
+            "off": false,
+            "count": 3,
+            "rate": 2.5,
+            "name": "checkout"
+        ]
+
+        let result = source.toOtelAttributes()
+
+        #expect(result["flag"] == .bool(true))
+        #expect(result["off"] == .bool(false))
+        #expect(result["count"] == .int(3))
+        #expect(result["rate"] == .double(2.5))
+        #expect(result["name"] == .string("checkout"))
+        #expect(result.count == 5)
+    }
+
+    // MARK: - Already-built attribute values are used, not skipped
+
+    @Test("uses an already-built AttributeValue directly")
+    func usesAttributeValue() {
+        let source: [String: Any] = [
+            "keep": "ok",
+            "attr": AttributeValue.string("preconverted")
+        ]
+
+        let result = source.toOtelAttributes()
+
+        #expect(result["keep"] == .string("ok"))
+        #expect(result["attr"] == .string("preconverted"))
+        #expect(result.count == 2)
+    }
+
+    @Test("nests a whole [String: AttributeValue] set under its key")
+    func usesWholeAttributeSet() {
+        let attributes: [String: AttributeValue] = [
+            "id": .string("u-1"),
+            "age": .int(30)
+        ]
+        let source: [String: Any] = [
+            "event": "signup",
+            "user": attributes
+        ]
+
+        let result = source.toOtelAttributes()
+
+        #expect(result["event"] == .string("signup"))
+        #expect(result["user"] == .set(AttributeSet(labels: [
+            "id": .string("u-1"),
+            "age": .int(30)
+        ])))
+        #expect(result.count == 2)
+    }
+
+    // MARK: - Nested map / dictionary
+
+    @Test("nests a Map/Dictionary value as an AttributeSet")
+    func nestsDictionary() {
+        let source: [String: Any] = [
+            "user": [
+                "id": "u-1",
+                "premium": true,
+                "address": ["city": "SF"]
+            ]
+        ]
+
+        let result = source.toOtelAttributes()
+
+        let expected: AttributeValue = .set(AttributeSet(labels: [
+            "id": .string("u-1"),
+            "premium": .bool(true),
+            "address": .set(AttributeSet(labels: ["city": .string("SF")]))
+        ]))
+        #expect(result["user"] == expected)
+        #expect(result.count == 1)
+    }
+
+    // MARK: - Arrays
+
+    @Test("converts an array value into an AttributeArray")
+    func convertsArray() {
+        let source: [String: Any] = ["scores": [1, 2, 3]]
+
+        let result = source.toOtelAttributes()
+
+        #expect(result["scores"] == .array(AttributeArray(values: [.int(1), .int(2), .int(3)])))
+    }
+
+    // MARK: - Unsupported values are dropped, never stringified
+
+    @Test("skips dates and arbitrary objects without stringifying")
+    func skipsArbitraryTypes() {
+        let date = Date(timeIntervalSince1970: 0)
+        let source: [String: Any] = [
+            "keep": 1,
+            "date": date,
+            "object": NSObject()
+        ]
+
+        let result = source.toOtelAttributes()
+
+        #expect(result["keep"] == .int(1))
+        #expect(result["date"] == nil)
+        #expect(result["object"] == nil)
+        #expect(result["date"] != .string(String(describing: date)))
+        #expect(result.count == 1)
+    }
+
+    // MARK: - NSNumber type fidelity
+
+    @Test("maps NSNumber bool/int/double by underlying type")
+    func nsNumberFidelity() {
+        let source: [String: Any] = [
+            "b": NSNumber(value: true),
+            "i": NSNumber(value: Int(7)),
+            "d": NSNumber(value: 1.5)
+        ]
+
+        let result = source.toOtelAttributes()
+
+        #expect(result["b"] == .bool(true))
+        #expect(result["i"] == .int(7))
+        #expect(result["d"] == .double(1.5))
+    }
+
+    @Test("empty payload yields empty attributes")
+    func emptyPayload() {
+        #expect([String: Any]().toOtelAttributes().isEmpty)
+    }
+
+    // MARK: - Segment e-commerce examples from analytics-taxonomy.md (§4.2)
+
+    @Test("Product Added flat payload")
+    func productAdded() {
+        let source: [String: Any] = [
+            "name": "Product Added",
+            "product_id": "SKU-1234",
+            "quantity": 2,
+            "price": 24.0,
+            "currency": "USD",
+            "cart_id": "cart_98f1"
+        ]
+
+        let result = source.toOtelAttributes()
+
+        #expect(result["name"] == .string("Product Added"))
+        #expect(result["product_id"] == .string("SKU-1234"))
+        #expect(result["quantity"] == .int(2))
+        #expect(result["price"] == .double(24.0))
+        #expect(result["currency"] == .string("USD"))
+        #expect(result["cart_id"] == .string("cart_98f1"))
+        #expect(result.count == 6)
+    }
+
+    @Test("Checkout Started nested products payload")
+    func checkoutStarted() {
+        let source: [String: Any] = [
+            "name": "Checkout Started",
+            "order_id": "ord_5521",
+            "value": 72.0,
+            "currency": "USD",
+            "products": [
+                ["product_id": "SKU-1234", "quantity": 2, "price": 24.0],
+                ["product_id": "SKU-9876", "quantity": 1, "price": 24.0]
+            ]
+        ]
+
+        let result = source.toOtelAttributes()
+
+        #expect(result["name"] == .string("Checkout Started"))
+        #expect(result["order_id"] == .string("ord_5521"))
+        #expect(result["value"] == .double(72.0))
+        #expect(result["currency"] == .string("USD"))
+        // The products array of objects nests as an array of attribute sets.
+        #expect(result["products"] == .array(AttributeArray(values: [
+            .set(AttributeSet(labels: [
+                "product_id": .string("SKU-1234"),
+                "quantity": .int(2),
+                "price": .double(24.0)
+            ])),
+            .set(AttributeSet(labels: [
+                "product_id": .string("SKU-9876"),
+                "quantity": .int(1),
+                "price": .double(24.0)
+            ]))
+        ])))
+        #expect(result.count == 5)
+    }
+}

--- a/Tests/ObservabilityTests/Bridge/OtelAttributesTests.swift
+++ b/Tests/ObservabilityTests/Bridge/OtelAttributesTests.swift
@@ -179,6 +179,18 @@ struct OtelAttributesTests {
         #expect(result.count == 1)
     }
 
+    // MARK: - 64-bit integers
+
+    @Test("preserves 64-bit integers without truncation")
+    func preservesLong() {
+        let big = 9_000_000_000 // > Int32.max
+        let source: [String: Any] = ["id": big]
+
+        let result = source.toOtelAttributes()
+
+        #expect(result["id"] == .int(big))
+    }
+
     // MARK: - NSNumber type fidelity
 
     @Test("maps NSNumber bool/int/double by underlying type")

--- a/Tests/ObservabilityTests/Bridge/OtelAttributesTests.swift
+++ b/Tests/ObservabilityTests/Bridge/OtelAttributesTests.swift
@@ -34,6 +34,28 @@ struct OtelAttributesTests {
         #expect(result.count == 5)
     }
 
+    @Test("keeps native Swift Bool/Int/Double scalars from a [String: Any] payload")
+    func nativeSwiftScalars() {
+        // Mirrors the LDObserve.shared.track / TestApp payload: native Swift
+        // scalar literals boxed in [String: Any] (not Foundation types).
+        let source: [String: Any] = [
+            "test-string": "ios",
+            "test-true": true,
+            "test-false": false,
+            "test-integer": 42,
+            "test-double": 3.14
+        ]
+
+        let result = source.toOtelAttributes()
+
+        #expect(result["test-string"] == .string("ios"))
+        #expect(result["test-true"] == .bool(true))
+        #expect(result["test-false"] == .bool(false))
+        #expect(result["test-integer"] == .int(42))
+        #expect(result["test-double"] == .double(3.14))
+        #expect(result.count == 5)
+    }
+
     // MARK: - Already-built attribute values are used, not skipped
 
     @Test("uses an already-built AttributeValue directly")

--- a/Tests/ObservabilityTests/Bridge/OtelAttributesTests.swift
+++ b/Tests/ObservabilityTests/Bridge/OtelAttributesTests.swift
@@ -72,6 +72,38 @@ struct OtelAttributesTests {
         #expect(result.count == 2)
     }
 
+    @Test("mixes native values with a pre-built OTel AttributeValue in one payload")
+    func mixesNativeAndOtelAttributes() {
+        // Mirrors a real `track`/`recordLog` payload: callers may favor native
+        // values (the `properties:` API) but can still embed pre-built OTel
+        // `AttributeValue`s (the `attributes:` API) in the same dictionary. Both
+        // must survive conversion. The example apps now use only native values,
+        // so this is the unit-test home for the OTel-attribute path.
+        let source: [String: Any] = [
+            "test-string": "ios",
+            "test-true": true,
+            "test-integer": 42,
+            "test-double": 3.14,
+            // Native nested map.
+            "test-swiftmap": ["test-string": "val"],
+            // Pre-built OTel attribute value supplied directly by the caller.
+            "test-AttributeValue": AttributeValue.set(.init(labels: ["string": .string("swift")]))
+        ]
+
+        let result = source.toOtelAttributes()
+
+        // Native values convert by their Swift type.
+        #expect(result["test-string"] == .string("ios"))
+        #expect(result["test-true"] == .bool(true))
+        #expect(result["test-integer"] == .int(42))
+        #expect(result["test-double"] == .double(3.14))
+        // Native nested map -> AttributeSet.
+        #expect(result["test-swiftmap"] == .set(AttributeSet(labels: ["test-string": .string("val")])))
+        // Pre-built OTel AttributeValue is used as-is.
+        #expect(result["test-AttributeValue"] == .set(AttributeSet(labels: ["string": .string("swift")])))
+        #expect(result.count == 6)
+    }
+
     @Test("nests a whole [String: AttributeValue] set under its key")
     func usesWholeAttributeSet() {
         let attributes: [String: AttributeValue] = [


### PR DESCRIPTION
## Summary
- Make `Observe.track` (and the `LDObserve` / `ObservabilityService` / `NoOpObservabilityService` conformances) take a plain `[String: Any]?` dictionary instead of `LDValue`, so callers need not depend on the LaunchDarkly flag model types. Object members are mapped to span attributes via the existing `AttributeConverter`.
- Add `ObjcLDObserveBridge.track` so the Flutter observability plugin can forward custom track events across the pigeon bridge into the native SDK — emitting the `track` span (gated by `analytics.trackEvents`) and the Session Replay `Track` timeline event.
- Update the `TestApp` track button to pass a plain dictionary.

The `afterTrack` hook path is unchanged: it already converts `LDValue` to attributes and routes through the dedicated `afterTrack` exporter, so it does not use `Observe.track`.

## Compatibility
This changes the public `track(key:data:metricValue:)` signature (`LDValue?` → `[String: Any]?`), which is a breaking change for direct callers of `LDObserve.shared.track`. `LDClient.track` (the flag SDK API) is unaffected.

## Test plan
- [x] `xcodebuild build -scheme LaunchDarklyObservability -destination 'generic/platform=iOS Simulator'` → BUILD SUCCEEDED
- [ ] Verify a manual `LDObserve.shared.track(key:data:)` call produces a `track` span and a Session Replay `Track` event

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public breaking signature change on `track`, plus altered span gating/kind and new bridge path that affects analytics attribution for cross-platform hosts.
> 
> **Overview**
> **Breaking API change:** `Observe.track` / `LDObserve.track` now take `[String: Any]?` instead of `LDValue?`, so direct callers no longer need LaunchDarkly value types. Payload keys are converted to OpenTelemetry span attributes via new `[String: Any].toOtelAttributes()` (nested dicts → sets, arrays → attribute arrays, unsupported values dropped).
> 
> Adds **`ObjcLDObserveBridge.track`** for Flutter/pigeon: dictionary payload, optional metric, and optional **context kind→key** map to annotate spans when the LD client lives outside this SDK; otherwise it falls back to `LDObserve.shared.track`.
> 
> **Telemetry behavior:** `track` spans are emitted only when both `analytics.trackEvents` and **`tracesApi.includeSpans`** are enabled, and spans are created as **CONSUMER** (not internal) via the tracer decorator. Session Replay `Track` events still broadcast regardless.
> 
> `.gitignore` now ignores all `*.xcconfig` (replacing a single `Secrets.xcconfig` entry). TestApp adds a nested “Checkout Started” demo; **`OtelAttributesTests`** cover the new mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 313edb7a99d445e8071989ae1c092f4dec539fed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->