### PR TITLE
fix: include userIdentifier in Session Replay Identify payload

### DIFF
--- a/Sources/LaunchDarklySessionReplay/Exporter/IdentifyItemPayload.swift
+++ b/Sources/LaunchDarklySessionReplay/Exporter/IdentifyItemPayload.swift
@@ -53,6 +53,7 @@ extension IdentifyItemPayload {
         }
         attributes["key"] = contextFriendlyName ?? canonicalKey
         attributes["canonicalKey"] = canonicalKey
+        attributes["userIdentifier"] = contextFriendlyName ?? canonicalKey
 
         return attributes
     }

--- a/Sources/LaunchDarklySessionReplay/Exporter/IdentifyItemPayload.swift
+++ b/Sources/LaunchDarklySessionReplay/Exporter/IdentifyItemPayload.swift
@@ -51,9 +51,10 @@ extension IdentifyItemPayload {
         if let contextFriendlyNameUnwrapped = options.contextFriendlyName, contextFriendlyNameUnwrapped.isNotEmpty {
             contextFriendlyName = contextFriendlyNameUnwrapped
         }
-        attributes["key"] = contextFriendlyName ?? canonicalKey
+        let displayKey = contextFriendlyName ?? canonicalKey
+        attributes["key"] = displayKey
         attributes["canonicalKey"] = canonicalKey
-        attributes["userIdentifier"] = contextFriendlyName ?? canonicalKey
+        attributes["userIdentifier"] = displayKey
 
         return attributes
     }


### PR DESCRIPTION
## Summary
- Mobile `Identify` Session Replay events rendered an empty description in the session player. The player resolves a description from `email || name || userIdentifier`, but the SDK only emitted `key` and `canonicalKey`.
- Emit `userIdentifier` (friendly name when set, otherwise the canonical key) in the Identify payload so mobile identifies show a description, matching the web `Identify` payload shape (`{ userIdentifier, ...userObject }`) without any frontend changes.

## Notes
- `email`/`name` are intentionally not plumbed: they aren't available at the identify hook call site (only `contextKeys` + `canonicalKey` are forwarded), and `userIdentifier` is sufficient to fix the empty-description bug.

## Test plan
- [ ] Build the package
- [ ] Trigger an identify and confirm the Session Replay Identify event renders a non-empty description in the session player

Made with [Cursor](https://cursor.com)