### PR TITLE
feat: richer click analytics (event.id/screen_id/screen_name, ldClick) + instrumentation gating

### DIFF
--- a/Sources/LaunchDarklyObservability/API/LDObserve.swift
+++ b/Sources/LaunchDarklyObservability/API/LDObserve.swift
@@ -75,4 +75,8 @@ extension LDObserve: Observe {
     public func trackScreenView(name: String, screenClass: String?, screenId: String?, category: String?, properties: [String: Any]?) {
         client.trackScreenView(name: name, screenClass: screenClass, screenId: screenId, category: category, properties: properties)
     }
+
+    public func trackClick(id: String?, tag: String?, text: String?, screenId: String?, x: Int?, y: Int?, properties: [String: Any]?) {
+        client.trackClick(id: id, tag: tag, text: text, screenId: screenId, x: x, y: y, properties: properties)
+    }
 }

--- a/Sources/LaunchDarklyObservability/API/ObservabilityOptions.swift
+++ b/Sources/LaunchDarklyObservability/API/ObservabilityOptions.swift
@@ -173,6 +173,18 @@ public struct ObservabilityOptions {
         /// events. Defaults to `.enabled`.
         let screens: FeatureFlag
         
+        /// Every automatic instrumentation feature enabled.
+        public static var enabled: Self {
+            .init(urlSession: .enabled, userTaps: .enabled, memory: .enabled, memoryWarnings: .enabled, cpu: .enabled, launchTimes: .enabled, screens: .enabled)
+        }
+        
+        /// Every automatic instrumentation feature disabled. Note this also turns off user-tap
+        /// detection (so no `click` spans are emitted regardless of ``Analytics/taps``) and
+        /// automatic screen detection (so no `screen_view`/Session Replay `Navigate` events).
+        public static var disabled: Self {
+            .init(urlSession: .disabled, userTaps: .disabled, memory: .disabled, memoryWarnings: .disabled, cpu: .disabled, launchTimes: .disabled, screens: .disabled)
+        }
+        
         public init(
             urlSession: FeatureFlag = .disabled,
             userTaps: FeatureFlag = .enabled,

--- a/Sources/LaunchDarklyObservability/API/ObservabilityOptions.swift
+++ b/Sources/LaunchDarklyObservability/API/ObservabilityOptions.swift
@@ -191,7 +191,7 @@ public struct ObservabilityOptions {
             memory: FeatureFlag = .disabled,
             memoryWarnings: FeatureFlag = .disabled,
             cpu: FeatureFlag = .disabled,
-            launchTimes: FeatureFlag = .disabled,
+            launchTimes: FeatureFlag = .enabled,
             screens: FeatureFlag = .enabled
         ) {
             self.urlSession = urlSession

--- a/Sources/LaunchDarklyObservability/API/ObservabilityOptions.swift
+++ b/Sources/LaunchDarklyObservability/API/ObservabilityOptions.swift
@@ -159,13 +159,13 @@ public struct ObservabilityOptions {
         let memory: FeatureFlag
         let memoryWarnings: FeatureFlag
         let cpu: FeatureFlag
-        /// Whether to emit legacy launch-time performance metrics. This currently only has an
-        /// effect on Android (TTID/TTFD histograms); on iOS the legacy per-scene launch-time
-        /// metric was refactored into the `app_launch` span, so this flag is presently inert on
-        /// iOS and is retained for cross-platform parity (it is propagated as a single option from
-        /// the Flutter SDK) and possible future use. The `app.start` span event on `app_launch`
-        /// (cold/warm via `start.type`, with `start.duration_ms`) is always attached when
-        /// ``Analytics/appLaunch`` is enabled and is never gated by this flag. Defaults to `.disabled`.
+        /// Whether to emit launch-time performance telemetry. On Android this also gates the legacy
+        /// TTID/TTFD histograms. On both platforms it gates the `app.start` span event on `app_launch`
+        /// (cold/warm via `start.type`, with `start.duration_ms`): when this flag is disabled the
+        /// `app.start` event is omitted and the `app_launch` span is anchored at the launch-detection
+        /// time (rather than back-dated to process start) so it carries no startup duration. The
+        /// `app_launch` span itself (with `event.launch_type` and version fields) is still emitted when
+        /// ``Analytics/appLaunch`` is enabled. Defaults to `.disabled`.
         let launchTimes: FeatureFlag
         /// Whether to automatically detect screen changes by swizzling
         /// `UIViewController`. This drives both the `screen_view` span (gated
@@ -228,8 +228,10 @@ public struct ObservabilityOptions {
         /// analytics taxonomy app-lifecycle events.
         let appLifecycle: FeatureFlag
         /// Whether to emit an `app_launch` span (with `event.launch_type` and version
-        /// fields, plus an `app.start` span event for the cold/warm startup dimension)
-        /// once per process launch. Maps to the analytics taxonomy `app_launch` event.
+        /// fields) once per process launch. Maps to the analytics taxonomy `app_launch`
+        /// event. The cold/warm startup dimension (`app.start` span event with
+        /// `start.type`/`start.duration_ms`) is attached only when
+        /// ``Instrumentation/launchTimes`` is also enabled.
         let appLaunch: FeatureFlag
         
         public static var enabled: Self {

--- a/Sources/LaunchDarklyObservability/API/Observe.swift
+++ b/Sources/LaunchDarklyObservability/API/Observe.swift
@@ -36,6 +36,23 @@ public protocol Observe: AnyObject, MetricsApi, LogsApi, TracesApi, ObserveConte
     ///     attached at lower precedence than the reserved `event.*` fields, so
     ///     they can never clobber the taxonomy.
     func trackScreenView(name: String, screenClass: String?, screenId: String?, category: String?, properties: [String: Any]?)
+    /// Manually record a `click` event as a `click` span.
+    ///
+    /// Use this to reproduce the taxonomy `click` event for interactions that automatic
+    /// tap capture cannot observe. Emitted through the same `analytics.taps` gate as
+    /// automatic click spans.
+    /// - Parameters:
+    ///   - id: Stable element identifier (`event.id`).
+    ///   - tag: Element tag/class (`event.tag`), e.g. `UIButton`.
+    ///   - text: Visible label/text of the element (`event.text`).
+    ///   - screenId: Stable screen id (`event.screen_id`). When `nil`, the current tracked
+    ///     screen id is used so the click correlates with the active `screen_view`.
+    ///   - x: Tap x coordinate in screen pixels (`event.x`).
+    ///   - y: Tap y coordinate in screen pixels (`event.y`).
+    ///   - properties: Optional custom attributes (same conversion rules as a `track`
+    ///     event's `properties`). Attached at lower precedence than the reserved `event.*`
+    ///     fields, so they can never clobber the taxonomy.
+    func trackClick(id: String?, tag: String?, text: String?, screenId: String?, x: Int?, y: Int?, properties: [String: Any]?)
 }
 
 extension Observe {
@@ -56,6 +73,12 @@ extension Observe {
     /// Convenience overload without `properties`, preserving the prior call shape.
     public func trackScreenView(name: String, screenClass: String?, screenId: String?, category: String?) {
         trackScreenView(name: name, screenClass: screenClass, screenId: screenId, category: category, properties: nil)
+    }
+
+    /// Convenience: record a `click` with the common element fields. The current screen id
+    /// is used unless `screenId` is supplied.
+    public func trackClick(id: String?, tag: String? = nil, text: String? = nil, screenId: String? = nil) {
+        trackClick(id: id, tag: tag, text: text, screenId: screenId, x: nil, y: nil, properties: nil)
     }
 }
 

--- a/Sources/LaunchDarklyObservability/API/SemanticConvention.swift
+++ b/Sources/LaunchDarklyObservability/API/SemanticConvention.swift
@@ -31,6 +31,7 @@ public enum SemanticConvention {
     public static let startDurationMs = "start.duration_ms"
     public static let eventScreenClass = "event.screen_class"
     public static let eventScreenId = "event.screen_id"
+    public static let eventScreenName = "event.screen_name"
     public static let eventPreviousScreen = "event.previous_screen"
     public static let eventCategory = "event.category"
     public static let eventType = "event.type"

--- a/Sources/LaunchDarklyObservability/API/View+ldClick.swift
+++ b/Sources/LaunchDarklyObservability/API/View+ldClick.swift
@@ -21,6 +21,9 @@ private struct LdClickModifier: ViewModifier {
     @ViewBuilder
     func body(content: Content) -> some View {
         if #available(iOS 16.0, tvOS 16.0, *) {
+            // `.global` is the root of the SwiftUI hierarchy: it matches UIKit window coordinates
+            // for a full-screen window but is screen-relative otherwise. The interaction resolver
+            // reconciles both spaces when matching, so taps still resolve under iPad multitasking.
             content.simultaneousGesture(
                 SpatialTapGesture(coordinateSpace: .global).onEnded { value in
                     LdClickRegistry.shared.record(id: id, location: value.location)

--- a/Sources/LaunchDarklyObservability/API/View+ldClick.swift
+++ b/Sources/LaunchDarklyObservability/API/View+ldClick.swift
@@ -1,0 +1,38 @@
+#if canImport(UIKit)
+import SwiftUI
+
+public extension View {
+    /// Tags this SwiftUI element so an auto-captured `click` event reports `event.id == id` when the
+    /// user taps it. Prefer a human-readable, stable id (e.g. `"checkout.pay_button"`).
+    ///
+    /// Unlike approaches that bridge the SwiftUI view tree into UIKit, this attaches a SwiftUI tap
+    /// gesture that fires during the tap and records the id; the SDK's interaction capture then uses
+    /// it. It relies only on public SwiftUI gesture APIs, so it is robust across SwiftUI/iOS versions,
+    /// and it does not modify `accessibilityIdentifier` or the view hierarchy. The underlying control
+    /// stays fully interactive (the gesture is attached simultaneously).
+    func ldClick(_ id: String) -> some View {
+        modifier(LdClickModifier(id: id))
+    }
+}
+
+private struct LdClickModifier: ViewModifier {
+    let id: String
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if #available(iOS 16.0, tvOS 16.0, *) {
+            content.simultaneousGesture(
+                SpatialTapGesture(coordinateSpace: .global).onEnded { value in
+                    LdClickRegistry.shared.record(id: id, location: value.location)
+                }
+            )
+        } else {
+            content.simultaneousGesture(
+                TapGesture().onEnded {
+                    LdClickRegistry.shared.record(id: id, location: nil)
+                }
+            )
+        }
+    }
+}
+#endif

--- a/Sources/LaunchDarklyObservability/API/View+ldId.swift
+++ b/Sources/LaunchDarklyObservability/API/View+ldId.swift
@@ -1,0 +1,15 @@
+#if canImport(UIKit)
+import UIKit
+
+public extension UIView {
+    /// Tags this view with a stable analytics identifier used as `event.id` for auto-captured
+    /// `click` events on this view (or its descendants, when the tap resolves to a child). Prefer a
+    /// human-readable, stable id (e.g. `"checkout.pay_button"`). Takes precedence over
+    /// `accessibilityIdentifier`.
+    ///
+    /// For SwiftUI, use the `.ldClick(_:)` view modifier instead.
+    func ldId(_ id: String) {
+        LdIdStorage.set(self, id: id)
+    }
+}
+#endif

--- a/Sources/LaunchDarklyObservability/Client/NoOpObservabilityService.swift
+++ b/Sources/LaunchDarklyObservability/Client/NoOpObservabilityService.swift
@@ -25,6 +25,8 @@ final class NoOpObservabilityService: Observe {
     func track(key: String, properties: [String: Any]?, metricValue: Double?) {}
 
     func trackScreenView(name: String, screenClass: String?, screenId: String?, category: String?, properties: [String: Any]?) {}
+
+    func trackClick(id: String?, tag: String?, text: String?, screenId: String?, x: Int?, y: Int?, properties: [String: Any]?) {}
 }
 
 extension NoOpObservabilityService {

--- a/Sources/LaunchDarklyObservability/Client/ObservabilityService.swift
+++ b/Sources/LaunchDarklyObservability/Client/ObservabilityService.swift
@@ -687,14 +687,18 @@ extension ObservabilityService: TrackEmitting {
         // load (`AppStartTime`) and end it at the launch-detection time carried by the signal, so
         // analytics timestamps reflect the real startup window and aren't skewed by SDK init work.
         let launchTime = Date(timeIntervalSince1970: signal.timestamp)
-        let spanStart = min(AppStartTime.stats.startDate, launchTime)
+        // The startup-performance dimension (cold/warm `start.type` + `start.duration_ms`) is gated by
+        // `instrumentation.launchTimes`. When it is off we also anchor the span at the launch-detection
+        // time instead of back-dating it to process start, so the span window carries no startup
+        // duration and `start.duration_ms` can't be recovered from it.
+        let includeLaunchTime = options.instrumentation.launchTimes.isEnabled
+        let spanStart = includeLaunchTime ? min(AppStartTime.stats.startDate, launchTime) : launchTime
 
         let span = tracer.startSpan(name: SemanticConvention.appLaunchSpanName, attributes: spanAttributes, startTime: spanStart)
         // Taxonomy §4.6: cold/warm lives on the `app.start` span event (orthogonal to
-        // `event.launch_type`). Always attach when known under `analytics.appLaunch`.
-        // `instrumentation.launchTimes` is inert on iOS (the legacy per-scene launch metric was
-        // folded into this span) and intentionally never gated this event.
-        if let startType = signal.startType {
+        // `event.launch_type`), attached under `analytics.appLaunch` and gated by
+        // `instrumentation.launchTimes`.
+        if includeLaunchTime, let startType = signal.startType {
             var eventAttributes: [String: AttributeValue] = [
                 SemanticConvention.startType: .string(startType.rawValue)
             ]

--- a/Sources/LaunchDarklyObservability/Client/ObservabilityService.swift
+++ b/Sources/LaunchDarklyObservability/Client/ObservabilityService.swift
@@ -39,7 +39,7 @@ final class ObservabilityService: InternalObserve {
     private var instruments = [AutoInstrumentation]()
     
     private let userInteractionManager: UserInteractionManager
-    private let screenStack = ScreenStack()
+    private let screenStack: ScreenStack
     private var screenViewManager: ScreenViewManager?
     /// Broadcasts each recorded screen view so Session Replay can emit `Navigate` events.
     private let screenViewSubject = PassthroughSubject<ScreenViewEvent, Never>()
@@ -203,10 +203,15 @@ final class ObservabilityService: InternalObserve {
         // `click` span. Capture still flows to Session Replay regardless of either flag.
         let userTapsEnabled = options.instrumentation.userTaps.isEnabled
         let publishTaps = options.analytics.taps.isEnabled
+        // Created as a local so the tap closure can read the current screen id without
+        // capturing `self` (which isn't fully initialized yet at this point in `init`).
+        let screenStack = ScreenStack()
+        self.screenStack = screenStack
         let userInteractionManager = UserInteractionManager(options: options, sessionManaging: sessionManager) { interaction in
             guard userTapsEnabled else { return }
             guard publishTaps else { return }
-            interaction.startEndSpan(tracer: tracerDecorator)
+            // Correlate the tap with the active screen (taxonomy §4.1 `event.screen_id`).
+            interaction.startEndSpan(tracer: tracerDecorator, screenId: screenStack.currentId)
         }
         self.userInteractionManager = userInteractionManager
 
@@ -463,6 +468,37 @@ extension ObservabilityService: Observe {
                 attributes: properties?.toOtelAttributes() ?? [:]
             )
         )
+    }
+
+    /// Manually emit a `click` span, mirroring the automatic tap instrumentation. Use this
+    /// to reproduce the taxonomy `click` event for interactions automatic capture can't observe.
+    ///
+    /// Gated by `analytics.taps` (the same flag as automatic click spans). When `screenId` is
+    /// `nil`, the current tracked screen id is used so the click correlates with the active
+    /// `screen_view`. Reserved `event.*` fields take precedence over caller `properties`,
+    /// matching the `screen_view`/`track` precedence model.
+    func trackClick(id: String?, tag: String?, text: String?, screenId: String?, x: Int?, y: Int?, properties: [String: Any]?) {
+        guard options.analytics.taps.isEnabled else { return }
+
+        let spanAttributes = ClickAttributes.build(
+            id: id,
+            tag: tag,
+            text: text,
+            // Default to the current screen so the click correlates with the active `screen_view`.
+            screenId: screenId ?? screenStack.currentId,
+            x: x,
+            y: y,
+            contextKeyAttributes: cachedContextKeyAttributes,
+            properties: properties?.toOtelAttributes() ?? [:]
+        )
+
+        // Mirror the automatic tap span: a CLIENT-kind `click` span built via the decorator.
+        let builder = tracerDecorator.spanBuilder(spanName: SemanticConvention.clickSpanName)
+        builder.setSpanKind(spanKind: .client)
+        for (key, value) in spanAttributes {
+            builder.setAttribute(key: key, value: value)
+        }
+        builder.startSpan().end()
     }
 }
 

--- a/Sources/LaunchDarklyObservability/Client/ObservabilityService.swift
+++ b/Sources/LaunchDarklyObservability/Client/ObservabilityService.swift
@@ -211,7 +211,7 @@ final class ObservabilityService: InternalObserve {
             guard userTapsEnabled else { return }
             guard publishTaps else { return }
             // Correlate the tap with the active screen (taxonomy §4.1 `event.screen_id`).
-            interaction.startEndSpan(tracer: tracerDecorator, screenId: screenStack.currentId)
+            interaction.startEndSpan(tracer: tracerDecorator, screenId: screenStack.currentId, screenName: screenStack.current)
         }
         self.userInteractionManager = userInteractionManager
 
@@ -297,7 +297,13 @@ extension ObservabilityService {
             )
         }
         
-        userInteractionManager.start()
+        // The touch-capture hook (UIWindow.sendEvent swizzle + hit-testing) is invasive, so it is
+        // only installed when something needs it: tap detection here (gated by
+        // `instrumentation.userTaps`) or Session Replay, which starts the same shared manager
+        // itself. With both off, no swizzle or hit-testing is installed.
+        if options.instrumentation.userTaps.isEnabled {
+            userInteractionManager.start()
+        }
 
         if options.instrumentation.screens.isEnabled {
             screenViewManager?.start()
@@ -486,6 +492,7 @@ extension ObservabilityService: Observe {
             text: text,
             // Default to the current screen so the click correlates with the active `screen_view`.
             screenId: screenId ?? screenStack.currentId,
+            screenName: screenStack.current,
             x: x,
             y: y,
             contextKeyAttributes: cachedContextKeyAttributes,

--- a/Sources/LaunchDarklyObservability/Client/ObservabilityService.swift
+++ b/Sources/LaunchDarklyObservability/Client/ObservabilityService.swift
@@ -207,11 +207,17 @@ final class ObservabilityService: InternalObserve {
         // capturing `self` (which isn't fully initialized yet at this point in `init`).
         let screenStack = ScreenStack()
         self.screenStack = screenStack
-        let userInteractionManager = UserInteractionManager(options: options, sessionManaging: sessionManager) { interaction in
+        let userInteractionManager = UserInteractionManager(
+            options: options,
+            sessionManaging: sessionManager,
+            // The active screen is read once at tap time and stamped onto the interaction, so the
+            // OTel span here and the Session Replay click event report the identical screen.
+            screenInfoProvider: { (screenStack.currentId, screenStack.current) }
+        ) { interaction in
             guard userTapsEnabled else { return }
             guard publishTaps else { return }
             // Correlate the tap with the active screen (taxonomy §4.1 `event.screen_id`).
-            interaction.startEndSpan(tracer: tracerDecorator, screenId: screenStack.currentId, screenName: screenStack.current)
+            interaction.startEndSpan(tracer: tracerDecorator, screenId: interaction.screenId, screenName: interaction.screenName)
         }
         self.userInteractionManager = userInteractionManager
 

--- a/Sources/LaunchDarklyObservability/UIInteractions/InputCaptureCoordinator.swift
+++ b/Sources/LaunchDarklyObservability/UIInteractions/InputCaptureCoordinator.swift
@@ -23,13 +23,20 @@ struct TouchSample: Sendable {
     let target: TouchTarget?
     /// Session id fixed at main-thread capture time (with location/target).
     let sessionId: String
+    /// Active screen (`event.screen_id`/`event.screen_name`) read on the main thread at capture
+    /// time. Fixed here - rather than later on the background interpreter/consumer - so a navigation
+    /// or `screen_view` recorded after the finger lifts can't misattribute the tap to a later screen.
+    let screenId: String?
+    let screenName: String?
 
-    init(touch: UITouch, window: UIWindow, target: TouchTarget?, sessionId: String) {
+    init(touch: UITouch, window: UIWindow, target: TouchTarget?, sessionId: String, screenId: String?, screenName: String?) {
         self.id = ObjectIdentifier(touch)
         self.location = touch.location(in: window)
         self.timestamp = touch.timestamp
         self.target = target
         self.sessionId = sessionId
+        self.screenId = screenId
+        self.screenName = screenName
         self.phase = switch touch.phase {
         case .began: .began
         case .moved: .moved
@@ -43,6 +50,9 @@ struct TouchSample: Sendable {
 
 public typealias TouchInteractionYield = @Sendable (TouchInteraction) -> Void
 public typealias PressInteractionYield = @Sendable (PressInteraction) -> Void
+/// Resolves the active screen (`event.screen_id` / `event.screen_name`) at the instant of a tap.
+/// Read on the main thread at capture time so it reflects the screen the tap actually landed on.
+public typealias ScreenInfoProvider = @Sendable () -> (screenId: String?, screenName: String?)
 
 final class InputCaptureCoordinator {
     private let source: UIEventSource
@@ -51,18 +61,21 @@ final class InputCaptureCoordinator {
     private let pressInterpreter: PressInterpreter
     private let receiverChecker: UIEventReceiverChecker
     private let sessionIdProvider: @Sendable () -> String
+    private let screenInfoProvider: ScreenInfoProvider
     var onTouch: TouchInteractionYield?
     var onPress: PressInteractionYield?
 
     init(targetResolver: TargetResolving = TargetResolver(),
          receiverChecker: UIEventReceiverChecker = UIEventReceiverChecker(),
-         sessionIdProvider: @Sendable @escaping () -> String) {
+         sessionIdProvider: @Sendable @escaping () -> String,
+         screenInfoProvider: @escaping ScreenInfoProvider = { (nil, nil) }) {
         self.targetResolver = targetResolver
         self.touchInterpreter = TouchInterpreter()
         self.pressInterpreter = PressInterpreter()
         self.source = UIWindowSwizzleSource()
         self.receiverChecker = receiverChecker
         self.sessionIdProvider = sessionIdProvider
+        self.screenInfoProvider = screenInfoProvider
     }
     
     func start() {
@@ -136,6 +149,9 @@ final class InputCaptureCoordinator {
     ) {
         guard let touches = event.allTouches else { return }
         let sessionId = sessionIdProvider()
+        // Read the active screen here on the main thread (alongside session/target), so it reflects
+        // the screen at the moment of the touch rather than whenever the background consumer runs.
+        let screen = screenInfoProvider()
         for touch in touches {
             let target: TouchTarget?
             if touch.phase == .began || touch.phase == .ended {
@@ -148,7 +164,9 @@ final class InputCaptureCoordinator {
                 touch: touch,
                 window: window,
                 target: target,
-                sessionId: sessionId
+                sessionId: sessionId,
+                screenId: screen.screenId,
+                screenName: screen.screenName
             )
             continuation.yield(.touch(touchSample))
         }

--- a/Sources/LaunchDarklyObservability/UIInteractions/InputCaptureCoordinator.swift
+++ b/Sources/LaunchDarklyObservability/UIInteractions/InputCaptureCoordinator.swift
@@ -80,22 +80,34 @@ final class InputCaptureCoordinator {
     
     func start() {
         let captureStream = AsyncStream<InteractionCaptureItem> { continuation in
-            source.start { [weak self] event, window in
+            source.start { [weak self] event, window, dispatchOriginal in
                 // Main thread part of work
-                guard let self else { return }
+                guard let self else { dispatchOriginal(); return }
                 
                 let trackWindow = receiverChecker.shouldTrack(window)
                 
                 switch event.type {
                 case .touches:
                     if trackWindow {
-                        processTouches(event: event, window: window, continuation: continuation)
+                        // Sample the active screen BEFORE the app handles the event. A tap handler
+                        // that navigates synchronously (e.g. list row -> detail) updates the screen
+                        // stack during `dispatchOriginal()`; sampling first keeps the tap attributed
+                        // to the screen it actually landed on rather than the destination. Target /
+                        // `ldId` resolution still happens after dispatch (inside `processTouches`),
+                        // because the SwiftUI `.ldClick` gesture only registers its id while the app
+                        // processes the event.
+                        let screen = screenInfoProvider()
+                        dispatchOriginal()
+                        processTouches(event: event, window: window, screen: screen, continuation: continuation)
                     } else {
+                        dispatchOriginal()
                         processTouchesAsPress(event: event, window: window, continuation: continuation)
                     }
                 case .presses:
+                    dispatchOriginal()
                     processPresses(event: event, window: window, continuation: continuation)
                 default:
+                    dispatchOriginal()
                     // `UIPhysicalKeyboardEvent` and other `UIPressesEvent` subclasses can use a `type`
                     // not exposed on `UIEvent.EventType` yet, so they fall through here instead of `.presses`.
                     if event is UIPressesEvent {
@@ -145,13 +157,14 @@ final class InputCaptureCoordinator {
     private func processTouches(
         event: UIEvent,
         window: UIWindow,
+        screen: (screenId: String?, screenName: String?),
         continuation: AsyncStream<InteractionCaptureItem>.Continuation
     ) {
         guard let touches = event.allTouches else { return }
         let sessionId = sessionIdProvider()
-        // Read the active screen here on the main thread (alongside session/target), so it reflects
-        // the screen at the moment of the touch rather than whenever the background consumer runs.
-        let screen = screenInfoProvider()
+        // `screen` was sampled on the main thread BEFORE the app handled the event (see `start`), so
+        // it reflects the screen the touch landed on even if a tap handler navigated synchronously
+        // during dispatch.
         for touch in touches {
             let target: TouchTarget?
             if touch.phase == .began || touch.phase == .ended {

--- a/Sources/LaunchDarklyObservability/UIInteractions/LdClickRegistry.swift
+++ b/Sources/LaunchDarklyObservability/UIInteractions/LdClickRegistry.swift
@@ -21,7 +21,10 @@ final class LdClickRegistry {
 
     private struct Entry {
         let id: String
-        /// Tap location in `.global` SwiftUI coordinates (≈ window coordinates), when available.
+        /// Tap location in SwiftUI `.global` coordinates, when available. `.global` is the root of the
+        /// SwiftUI hierarchy: it equals UIKit window coordinates for a full-screen window but is
+        /// screen-relative when the window isn't (iPad Split View / Slide Over / Stage Manager). The
+        /// lookup therefore matches against both the window point and the screen-converted point.
         let location: CGPoint?
         let time: TimeInterval
     }
@@ -54,24 +57,34 @@ final class LdClickRegistry {
         lock.unlock()
     }
 
-    /// Returns the id of the most recent entry whose recorded location is within tolerance of
-    /// [point] (window coordinates), or nil. Only entries that carry a location are considered;
-    /// locationless entries are resolved separately via ``locationlessId()`` so they can never
-    /// match an arbitrary point. Non-consuming: entries are left in place (and expire by TTL) so
-    /// multiple capture pipelines resolving the same tap all see the id.
-    func id(at point: CGPoint) -> String? {
+    /// Returns the id of the most recent located entry whose recorded location is within tolerance
+    /// of any of [points], or nil. Passing several candidate points lets the caller reconcile
+    /// coordinate spaces: a `.ldClick` location is recorded in SwiftUI `.global`, which the resolver
+    /// can't disambiguate from UIKit window vs screen coordinates ahead of time (they diverge when
+    /// the window isn't full-screen), so it supplies both. Only entries that carry a location are
+    /// considered; locationless entries are resolved separately via ``locationlessId()`` so they can
+    /// never match an arbitrary point. Non-consuming: entries are left in place (and expire by TTL)
+    /// so multiple capture pipelines resolving the same tap all see the id.
+    func id(atAnyOf points: [CGPoint]) -> String? {
         let now = ProcessInfo.processInfo.systemUptime
         lock.lock()
         defer { lock.unlock() }
         prune(now: now)
         for entry in entries.reversed() {
             guard let location = entry.location else { continue }
-            if abs(location.x - point.x) <= locationTolerance,
-               abs(location.y - point.y) <= locationTolerance {
-                return entry.id
+            for point in points {
+                if abs(location.x - point.x) <= locationTolerance,
+                   abs(location.y - point.y) <= locationTolerance {
+                    return entry.id
+                }
             }
         }
         return nil
+    }
+
+    /// Convenience for a single candidate point. See ``id(atAnyOf:)``.
+    func id(at point: CGPoint) -> String? {
+        id(atAnyOf: [point])
     }
 
     /// Returns the id of the most recent *locationless* entry, but only when it is fresh enough to

--- a/Sources/LaunchDarklyObservability/UIInteractions/LdClickRegistry.swift
+++ b/Sources/LaunchDarklyObservability/UIInteractions/LdClickRegistry.swift
@@ -1,0 +1,75 @@
+#if canImport(UIKit)
+import UIKit
+
+/// Bridges SwiftUI `.ldClick(_:)` taps to the auto-capture pipeline.
+///
+/// `.ldClick(_:)` attaches a SwiftUI tap gesture that fires *during* the tap and records the id
+/// here. The SDK swizzles `UIWindow.sendEvent` and calls the original implementation first (which is
+/// what fires SwiftUI's gesture callbacks), then resolves the touch target in the same event cycle —
+/// so a freshly recorded id is available when `TargetResolver` runs and is used as `event.id`.
+///
+/// This is best-effort: it never emits its own span, so it can never create duplicate `click`
+/// events. If no fresh id matches (e.g. an unusual SwiftUI version defers the gesture callback), the
+/// click span is simply emitted without an id, exactly as it would be today.
+///
+/// Lookups are non-consuming: a single tap is read by multiple independent capture pipelines
+/// (Observability emits the `click` span; Session Replay emits its own click event), each with its
+/// own `TargetResolver`. Entries expire by TTL instead of being removed on read so every pipeline
+/// resolving the same tap sees the same id.
+final class LdClickRegistry {
+    static let shared = LdClickRegistry()
+
+    private struct Entry {
+        let id: String
+        /// Tap location in `.global` SwiftUI coordinates (≈ window coordinates), when available.
+        let location: CGPoint?
+        let time: TimeInterval
+    }
+
+    private let lock = NSLock()
+    private var entries: [Entry] = []
+
+    /// How long a recorded tap remains eligible. Resolution happens within the same `sendEvent`
+    /// cycle, so this only needs to cover that brief window plus scheduling jitter.
+    private let ttl: TimeInterval = 0.75
+    /// Allowed distance between the gesture location and the resolved touch point.
+    private let locationTolerance: CGFloat = 24
+
+    init() {}
+
+    /// Records a `.ldClick(_:)` activation. Called on the main thread from the SwiftUI gesture.
+    func record(id: String, location: CGPoint?) {
+        guard !id.isEmpty else { return }
+        let now = ProcessInfo.processInfo.systemUptime
+        lock.lock()
+        prune(now: now)
+        entries.append(Entry(id: id, location: location, time: now))
+        lock.unlock()
+    }
+
+    /// Returns the best-matching id for a touch at [point] (window coordinates), or nil. Prefers the
+    /// most recent entry whose recorded location is within tolerance; entries without a location
+    /// (older SwiftUI versions) match on recency alone. Non-consuming: entries are left in place (and
+    /// expire by TTL) so multiple capture pipelines resolving the same tap all see the id.
+    func id(at point: CGPoint) -> String? {
+        let now = ProcessInfo.processInfo.systemUptime
+        lock.lock()
+        defer { lock.unlock() }
+        prune(now: now)
+        for entry in entries.reversed() {
+            if let location = entry.location {
+                guard abs(location.x - point.x) <= locationTolerance,
+                      abs(location.y - point.y) <= locationTolerance else {
+                    continue
+                }
+            }
+            return entry.id
+        }
+        return nil
+    }
+
+    private func prune(now: TimeInterval) {
+        entries.removeAll { now - $0.time > ttl }
+    }
+}
+#endif

--- a/Sources/LaunchDarklyObservability/UIInteractions/LdClickRegistry.swift
+++ b/Sources/LaunchDarklyObservability/UIInteractions/LdClickRegistry.swift
@@ -34,6 +34,13 @@ final class LdClickRegistry {
     private let ttl: TimeInterval = 0.75
     /// Allowed distance between the gesture location and the resolved touch point.
     private let locationTolerance: CGFloat = 24
+    /// How long a *locationless* entry (older SwiftUI versions that report no tap coordinates)
+    /// stays eligible. Such entries can't be matched geometrically, so they would otherwise match
+    /// any touch point for the whole `ttl` and let a later tap elsewhere inherit a previous
+    /// button's id. Bounding them to a tight window keeps the match to the current event cycle
+    /// (all pipelines resolve a tap back-to-back, well within this) without bleeding into the
+    /// user's next, unrelated tap.
+    private let locationlessFreshness: TimeInterval = 0.1
 
     init() {}
 
@@ -47,23 +54,42 @@ final class LdClickRegistry {
         lock.unlock()
     }
 
-    /// Returns the best-matching id for a touch at [point] (window coordinates), or nil. Prefers the
-    /// most recent entry whose recorded location is within tolerance; entries without a location
-    /// (older SwiftUI versions) match on recency alone. Non-consuming: entries are left in place (and
-    /// expire by TTL) so multiple capture pipelines resolving the same tap all see the id.
+    /// Returns the id of the most recent entry whose recorded location is within tolerance of
+    /// [point] (window coordinates), or nil. Only entries that carry a location are considered;
+    /// locationless entries are resolved separately via ``locationlessId()`` so they can never
+    /// match an arbitrary point. Non-consuming: entries are left in place (and expire by TTL) so
+    /// multiple capture pipelines resolving the same tap all see the id.
     func id(at point: CGPoint) -> String? {
         let now = ProcessInfo.processInfo.systemUptime
         lock.lock()
         defer { lock.unlock() }
         prune(now: now)
         for entry in entries.reversed() {
-            if let location = entry.location {
-                guard abs(location.x - point.x) <= locationTolerance,
-                      abs(location.y - point.y) <= locationTolerance else {
-                    continue
-                }
+            guard let location = entry.location else { continue }
+            if abs(location.x - point.x) <= locationTolerance,
+               abs(location.y - point.y) <= locationTolerance {
+                return entry.id
             }
-            return entry.id
+        }
+        return nil
+    }
+
+    /// Returns the id of the most recent *locationless* entry, but only when it is fresh enough to
+    /// belong to the current event cycle (see ``locationlessFreshness``). Older SwiftUI versions
+    /// report taps without coordinates, so these can't be matched geometrically; the freshness
+    /// bound keeps a later tap elsewhere from inheriting a previous button's id. Callers should
+    /// treat this as a last resort, below both a located match and a UIKit `UIView.ldId`.
+    /// Non-consuming.
+    func locationlessId() -> String? {
+        let now = ProcessInfo.processInfo.systemUptime
+        lock.lock()
+        defer { lock.unlock() }
+        prune(now: now)
+        for entry in entries.reversed() {
+            guard entry.location == nil else { continue }
+            if now - entry.time <= locationlessFreshness {
+                return entry.id
+            }
         }
         return nil
     }

--- a/Sources/LaunchDarklyObservability/UIInteractions/LdIdStorage.swift
+++ b/Sources/LaunchDarklyObservability/UIInteractions/LdIdStorage.swift
@@ -1,0 +1,18 @@
+#if canImport(UIKit)
+import UIKit
+
+/// Stores a developer-supplied analytics identifier (`ldId`) on a `UIView` via an associated
+/// object. This is a dedicated channel, separate from `accessibilityIdentifier`, so the two can
+/// differ and `ldId` can take precedence when resolving `event.id` for `click` events.
+enum LdIdStorage {
+    private static var key: UInt8 = 0
+
+    static func set(_ view: UIView, id: String) {
+        objc_setAssociatedObject(view, &key, id, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+    }
+
+    static func get(_ view: UIView) -> String? {
+        objc_getAssociatedObject(view, &key) as? String
+    }
+}
+#endif

--- a/Sources/LaunchDarklyObservability/UIInteractions/ScreenView/ScreenStack.swift
+++ b/Sources/LaunchDarklyObservability/UIInteractions/ScreenView/ScreenStack.swift
@@ -8,9 +8,11 @@ import Foundation
 ///
 /// `record(_:id:)` returns the name of the screen that was viewed immediately before
 /// the supplied one, then updates the stack. Re-recording the screen that is
-/// already on top is treated as a no-op (its `previous_screen` stays stable and
-/// the stack is left unchanged), so it is robust to UIKit re-presenting the same
-/// controller (e.g. modal dismissals calling `viewDidAppear` again).
+/// already on top keeps history stable (its `previous_screen` stays the same and no
+/// new entry is pushed), so it is robust to UIKit re-presenting the same controller
+/// (e.g. modal dismissals calling `viewDidAppear` again). The matched entry's stored
+/// `name`/`id` are still refreshed to the latest values, so `current`/`currentId`
+/// never lag behind the most recent `screen_view` for the same identity.
 ///
 /// Screen identity is keyed on `screenId` when supplied, falling back to `name`.
 /// This keeps two distinct screens that share a display name (e.g. a detail screen
@@ -37,17 +39,22 @@ final class ScreenStack {
     func record(_ name: String, id: String? = nil) -> String? {
         let key = id ?? name
         return queue.sync {
-            // Re-appearance of the current top: keep history stable.
+            // Re-appearance of the current top: keep history stable, but refresh the
+            // stored name/id so `current`/`currentId` track the latest screen view
+            // (the same `screenId` can be re-recorded with an updated display name).
             if stack.last?.key == key {
+                stack[stack.count - 1] = Entry(key: key, name: name, id: id)
                 return stack.count >= 2 ? stack[stack.count - 2].name : nil
             }
 
             let previous = stack.last?.name
 
             // If the screen already exists deeper in the stack, treat the
-            // appearance as a "pop back" to it and trim everything above.
+            // appearance as a "pop back" to it and trim everything above. Refresh the
+            // matched entry's name/id to the latest values so it doesn't go stale.
             if let existingIndex = stack.lastIndex(where: { $0.key == key }) {
                 stack.removeSubrange((existingIndex + 1)..<stack.count)
+                stack[existingIndex] = Entry(key: key, name: name, id: id)
             } else {
                 stack.append(Entry(key: key, name: name, id: id))
             }

--- a/Sources/LaunchDarklyObservability/UIInteractions/ScreenView/ScreenStack.swift
+++ b/Sources/LaunchDarklyObservability/UIInteractions/ScreenView/ScreenStack.swift
@@ -22,6 +22,9 @@ final class ScreenStack {
         let key: String
         /// Human-readable name reported as `previous_screen`.
         let name: String
+        /// Caller-supplied stable screen id (`event.screen_id`), if any. `nil` when the
+        /// screen was recorded without an explicit id (identity then falls back to `name`).
+        let id: String?
     }
 
     private let queue = DispatchQueue(label: "com.launchdarkly.observability.screenStack")
@@ -46,7 +49,7 @@ final class ScreenStack {
             if let existingIndex = stack.lastIndex(where: { $0.key == key }) {
                 stack.removeSubrange((existingIndex + 1)..<stack.count)
             } else {
-                stack.append(Entry(key: key, name: name))
+                stack.append(Entry(key: key, name: name, id: id))
             }
 
             return previous
@@ -56,6 +59,13 @@ final class ScreenStack {
     /// The most recently viewed screen name, if any.
     var current: String? {
         queue.sync { stack.last?.name }
+    }
+
+    /// The stable id (`event.screen_id`) of the most recently viewed screen, if it had one.
+    /// Used to attach `event.screen_id` to `click` spans so taps correlate with the current
+    /// `screen_view`. Returns `nil` when the current screen was recorded without an id.
+    var currentId: String? {
+        queue.sync { stack.last?.id }
     }
 
     /// Test/diagnostic snapshot of the current stack (screen names).

--- a/Sources/LaunchDarklyObservability/UIInteractions/TargetResolver.swift
+++ b/Sources/LaunchDarklyObservability/UIInteractions/TargetResolver.swift
@@ -49,7 +49,11 @@ final class TargetResolver: TargetResolving {
         }
         
         let semanticView = nearestSemanticView(view: hitView)
-        let ldId = resolveLdId(hitView: hitView, windowPoint: point)
+        // `.ldClick` records its location in SwiftUI `.global`, which equals window coordinates for a
+        // full-screen window but is screen-relative otherwise (iPad Split View / Slide Over / Stage
+        // Manager). Supply both so the registry can match whichever space `.global` resolved to.
+        let screenPoint = window.convert(point, to: window.screen.coordinateSpace)
+        let ldId = resolveLdId(hitView: hitView, candidatePoints: [point, screenPoint])
         return touchTarget(for: semanticView, ldId: ldId, window: window)
     }
 
@@ -80,12 +84,13 @@ final class TargetResolver: TargetResolving {
     /// when none is found.
     ///
     /// Priority, most to least precise:
-    /// 1. A `.ldClick(_:)` gesture recorded at this exact point (SwiftUI, location-matched).
+    /// 1. A `.ldClick(_:)` gesture recorded at this tap (SwiftUI, location-matched against any of
+    ///    [candidatePoints], which cover the window/screen coordinate spaces `.global` may use).
     /// 2. `UIView.ldId(_:)` on the hit view or an ancestor (UIKit).
     /// 3. A locationless `.ldClick(_:)` entry (older SwiftUI versions that report no coordinates),
     ///    used only as a last resort so it can't mask a real UIKit id or bleed into a later tap.
-    private func resolveLdId(hitView: UIView, windowPoint: CGPoint) -> String? {
-        if let id = LdClickRegistry.shared.id(at: windowPoint) {
+    private func resolveLdId(hitView: UIView, candidatePoints: [CGPoint]) -> String? {
+        if let id = LdClickRegistry.shared.id(atAnyOf: candidatePoints) {
             return id
         }
         if let id = ldIdWalkingUp(from: hitView) {

--- a/Sources/LaunchDarklyObservability/UIInteractions/TargetResolver.swift
+++ b/Sources/LaunchDarklyObservability/UIInteractions/TargetResolver.swift
@@ -4,6 +4,9 @@ import UIKit
 public struct TouchTarget: Sendable {
     public let className: String?
     public let accessibilityIdentifier: String?
+    /// Developer-supplied analytics identifier set via `.ldClick(_:)` (SwiftUI) / `UIView.ldId(_:)`
+    /// (UIKit). Preferred over `accessibilityIdentifier` when resolving `event.id` for `click` events.
+    public let ldId: String?
     public let text: String?
     public let isAccessibilityElement: Bool?
     public let rectInWindow: CGRect
@@ -11,10 +14,11 @@ public struct TouchTarget: Sendable {
     public let rowIndex: IndexPath?
     public let sceneId: String?
     
-    public init(className: String?, accessibilityIdentifier: String?, text: String? = nil, isAccessibilityElement: Bool?, rectInWindow: CGRect, rectOnScreen: CGRect, rowIndex: IndexPath?, sceneId: String?) {
+    public init(className: String?, accessibilityIdentifier: String?, ldId: String? = nil, text: String? = nil, isAccessibilityElement: Bool?, rectInWindow: CGRect, rectOnScreen: CGRect, rowIndex: IndexPath?, sceneId: String?) {
         // Make sure we have Swift string not NSString to transer struct between threads
         self.className = className.map { String($0) }
         self.accessibilityIdentifier = accessibilityIdentifier.map { String($0) }
+        self.ldId = ldId.map { String($0) }
         self.text = text.map { String($0) }
         self.isAccessibilityElement = isAccessibilityElement
         self.rectInWindow = rectInWindow
@@ -44,24 +48,51 @@ final class TargetResolver: TargetResolving {
             return nil
         }
         
-        return touchTarget(for: nearestSemanticView(view: hitView), window: window)
+        let semanticView = nearestSemanticView(view: hitView)
+        let ldId = resolveLdId(hitView: hitView, windowPoint: point)
+        return touchTarget(for: semanticView, ldId: ldId, window: window)
     }
 
     func resolve(press: UIPress, window: UIWindow) -> TouchTarget? {
         guard let hitView = press.responder as? UIView else { return nil }
-        return touchTarget(for: nearestSemanticView(view: hitView), window: window)
+        return touchTarget(for: nearestSemanticView(view: hitView), ldId: ldIdWalkingUp(from: hitView), window: window)
     }
     
-    private func touchTarget(for semanticView: UIView, window: UIWindow) -> TouchTarget {
+    private func touchTarget(for semanticView: UIView, ldId: String?, window: UIWindow) -> TouchTarget {
         let rectWin = semanticView.convert(semanticView.bounds, to: window)
         return TouchTarget(className: String(describing: type(of: semanticView)),
                            accessibilityIdentifier: semanticView.accessibilityIdentifier,
+                           ldId: ldId,
                            text: semanticView.extractViewInfo().title,
                            isAccessibilityElement: semanticView.isAccessibilityElement,
                            rectInWindow: rectWin,
                            rectOnScreen: window.convert(rectWin, to: nil),
                            rowIndex: nil,
                            sceneId: window.windowScene?.session.persistentIdentifier)
+    }
+
+    /// Resolves the developer-supplied analytics id for a tap.
+    ///
+    /// SwiftUI taps are supplied via the `.ldClick(_:)` modifier, whose gesture records the id in
+    /// `LdClickRegistry` during the tap; since the SDK calls the original `UIWindow.sendEvent` (which
+    /// fires that gesture) before resolving the target, the id is available here in the same event
+    /// cycle. UIKit views use `UIView.ldId(_:)`, read by walking up the view hierarchy. Returns `nil`
+    /// when none is found.
+    private func resolveLdId(hitView: UIView, windowPoint: CGPoint) -> String? {
+        if let id = LdClickRegistry.shared.id(at: windowPoint) {
+            return id
+        }
+        return ldIdWalkingUp(from: hitView)
+    }
+
+    /// Walks up from [view] returning the nearest ancestor's `ldId` (set via `UIView.ldId(_:)`), or `nil`.
+    private func ldIdWalkingUp(from view: UIView) -> String? {
+        var v: UIView? = view
+        while let cur = v {
+            if let id = LdIdStorage.get(cur), !id.isEmpty { return id }
+            v = cur.superview
+        }
+        return nil
     }
     
     private func nearestSemanticView(view: UIView) -> UIView {

--- a/Sources/LaunchDarklyObservability/UIInteractions/TargetResolver.swift
+++ b/Sources/LaunchDarklyObservability/UIInteractions/TargetResolver.swift
@@ -78,11 +78,20 @@ final class TargetResolver: TargetResolving {
     /// fires that gesture) before resolving the target, the id is available here in the same event
     /// cycle. UIKit views use `UIView.ldId(_:)`, read by walking up the view hierarchy. Returns `nil`
     /// when none is found.
+    ///
+    /// Priority, most to least precise:
+    /// 1. A `.ldClick(_:)` gesture recorded at this exact point (SwiftUI, location-matched).
+    /// 2. `UIView.ldId(_:)` on the hit view or an ancestor (UIKit).
+    /// 3. A locationless `.ldClick(_:)` entry (older SwiftUI versions that report no coordinates),
+    ///    used only as a last resort so it can't mask a real UIKit id or bleed into a later tap.
     private func resolveLdId(hitView: UIView, windowPoint: CGPoint) -> String? {
         if let id = LdClickRegistry.shared.id(at: windowPoint) {
             return id
         }
-        return ldIdWalkingUp(from: hitView)
+        if let id = ldIdWalkingUp(from: hitView) {
+            return id
+        }
+        return LdClickRegistry.shared.locationlessId()
     }
 
     /// Walks up from [view] returning the nearest ancestor's `ldId` (set via `UIView.ldId(_:)`), or `nil`.

--- a/Sources/LaunchDarklyObservability/UIInteractions/TouchInteraction.swift
+++ b/Sources/LaunchDarklyObservability/UIInteractions/TouchInteraction.swift
@@ -27,6 +27,14 @@ public struct TouchInteraction: Sendable {
     public let timestamp: TimeInterval
     public let target: TouchTarget?
     public let sessionId: String
+    /// Stable id (`event.screen_id`) of the active screen at the moment of the tap, stamped from the
+    /// live `ScreenStack` when the interaction is captured. Travels with the interaction so both the
+    /// OpenTelemetry `click` span and the Session Replay click event report the same screen, instead
+    /// of Session Replay lagging on an export-time `Navigate`.
+    public var screenId: String? = nil
+    /// Human-readable name (`event.screen_name`) of the active screen at the moment of the tap. See
+    /// ``screenId``.
+    public var screenName: String? = nil
 }
 
 public enum SwipeDirection: Sendable {

--- a/Sources/LaunchDarklyObservability/UIInteractions/TouchInteraction.swift
+++ b/Sources/LaunchDarklyObservability/UIInteractions/TouchInteraction.swift
@@ -27,10 +27,11 @@ public struct TouchInteraction: Sendable {
     public let timestamp: TimeInterval
     public let target: TouchTarget?
     public let sessionId: String
-    /// Stable id (`event.screen_id`) of the active screen at the moment of the tap, stamped from the
-    /// live `ScreenStack` when the interaction is captured. Travels with the interaction so both the
-    /// OpenTelemetry `click` span and the Session Replay click event report the same screen, instead
-    /// of Session Replay lagging on an export-time `Navigate`.
+    /// Stable id (`event.screen_id`) of the active screen at the moment of the tap, read from the live
+    /// `ScreenStack` on the main thread when the touch is captured (not later on the background
+    /// interpreter/consumer). Travels with the interaction so both the OpenTelemetry `click` span and
+    /// the Session Replay click event report the same screen, and so a navigation after the finger
+    /// lifts can't misattribute the tap to a later screen.
     public var screenId: String? = nil
     /// Human-readable name (`event.screen_name`) of the active screen at the moment of the tap. See
     /// ``screenId``.

--- a/Sources/LaunchDarklyObservability/UIInteractions/TouchInterpreter.swift
+++ b/Sources/LaunchDarklyObservability/UIInteractions/TouchInterpreter.swift
@@ -42,7 +42,9 @@ final class TouchInterpreter {
                                                    startTimestamp: touchSample.timestamp + uptimeDifference,
                                                    timestamp: touchSample.timestamp + uptimeDifference,
                                                    target: touchSample.target,
-                                                   sessionId: sessionId)
+                                                   sessionId: sessionId,
+                                                   screenId: touchSample.screenId,
+                                                   screenName: touchSample.screenName)
             yield(downInteraction)
 
         case .moved:
@@ -60,7 +62,9 @@ final class TouchInterpreter {
                                                        startTimestamp: track.start + uptimeDifference,
                                                        timestamp: touchSample.timestamp + uptimeDifference,
                                                        target: touchSample.target,
-                                                       sessionId: sessionId)
+                                                       sessionId: sessionId,
+                                                       screenId: touchSample.screenId,
+                                                       screenName: touchSample.screenName)
                 track.points.removeAll()
                 track.start = lastPoint.timestamp - uptimeDifference
                 track.startPoint = touchSample.location
@@ -94,7 +98,9 @@ final class TouchInterpreter {
                                                  startTimestamp: startTimestamp + uptimeDifference,
                                                  timestamp: touchSample.timestamp + uptimeDifference,
                                                  target: touchSample.target,
-                                                 sessionId: sessionId)
+                                                 sessionId: sessionId,
+                                                 screenId: touchSample.screenId,
+                                                 screenName: touchSample.screenName)
             yield(upInteraction)
 
             // touchPath
@@ -105,7 +111,9 @@ final class TouchInterpreter {
                                                 startTimestamp: startTimestamp + uptimeDifference,
                                                 timestamp: touchSample.timestamp + uptimeDifference,
                                                 target: touchSample.target,
-                                                sessionId: sessionId)
+                                                sessionId: sessionId,
+                                                screenId: touchSample.screenId,
+                                                screenName: touchSample.screenName)
             yield(moveInteraction)
         case .unknown:
             () //NOOP
@@ -120,7 +128,9 @@ final class TouchInterpreter {
                                                startTimestamp: startTimestamp + uptimeDifference,
                                                timestamp: touchSample.timestamp + uptimeDifference,
                                                target: touchSample.target,
-                                               sessionId: touchSample.sessionId)
+                                               sessionId: touchSample.sessionId,
+                                               screenId: touchSample.screenId,
+                                               screenName: touchSample.screenName)
         if let lastPoint = track.points.last {
             track.points.removeAll()
             track.start = lastPoint.timestamp - uptimeDifference

--- a/Sources/LaunchDarklyObservability/UIInteractions/UIEventSource.swift
+++ b/Sources/LaunchDarklyObservability/UIInteractions/UIEventSource.swift
@@ -1,7 +1,17 @@
 import UIKit
 
 public protocol UIEventSource: AnyObject {
-    func start(yield: @escaping (UIEvent, UIWindow) -> Void)
+    /// Installs the event hook. For every `UIWindow.sendEvent`, the source invokes `handler`
+    /// with the event, its window, and a `dispatchOriginal` thunk that forwards the event to the
+    /// app's original `sendEvent` implementation.
+    ///
+    /// The handler controls when the app sees the event by calling `dispatchOriginal()`. This lets
+    /// a consumer sample state that the app mutates synchronously during dispatch (e.g. the active
+    /// screen, which a navigating tap handler changes) *before* calling `dispatchOriginal()`, while
+    /// still resolving anything that the app populates *during* dispatch (e.g. SwiftUI `.ldClick`
+    /// gesture ids) *after* it. The handler must call `dispatchOriginal()` exactly once, otherwise
+    /// the app stops receiving events.
+    func start(handler: @escaping (UIEvent, UIWindow, _ dispatchOriginal: () -> Void) -> Void)
     func stop()
 }
 

--- a/Sources/LaunchDarklyObservability/UIInteractions/UIWindowSwizzleSource.swift
+++ b/Sources/LaunchDarklyObservability/UIInteractions/UIWindowSwizzleSource.swift
@@ -11,7 +11,7 @@ final class UIWindowSwizzleSource: UIEventSource, AnyObject {
     init() {
     }
     
-    func start(yield: @escaping (UIEvent, UIWindow) -> Void) {
+    func start(handler: @escaping (UIEvent, UIWindow, () -> Void) -> Void) {
         guard !isActive else { return }
         
         guard let originalMethod = class_getInstanceMethod(UIWindow.self, UIWindowSwizzleSource.sendEvenSelector) else { return }
@@ -19,12 +19,15 @@ final class UIWindowSwizzleSource: UIEventSource, AnyObject {
         let swizzledSendEventBlock: @convention(block) (UIWindow, UIEvent) -> Void = { [weak self] window, event in
             guard let self else { return }
             
-            if let originalIMP = self.originalIMP {
+            // Forward to the app's original `sendEvent`. Handed to the handler as a thunk so the
+            // handler decides when the app processes the event relative to its own capture work.
+            let dispatchOriginal: () -> Void = { [weak self] in
+                guard let self, let originalIMP = self.originalIMP else { return }
                 let castedIMP = unsafeBitCast(originalIMP, to: SendEventRef.self)
                 castedIMP(window, UIWindowSwizzleSource.sendEvenSelector, event)
             }
             
-            yield(event, window)
+            handler(event, window, dispatchOriginal)
         }
         
         let swizzledIMP = imp_implementationWithBlock(unsafeBitCast(swizzledSendEventBlock, to: AnyObject.self))

--- a/Sources/LaunchDarklyObservability/UIInteractions/UIWindowSwizzleSource.swift
+++ b/Sources/LaunchDarklyObservability/UIInteractions/UIWindowSwizzleSource.swift
@@ -29,6 +29,7 @@ final class UIWindowSwizzleSource: UIEventSource, AnyObject {
         
         let swizzledIMP = imp_implementationWithBlock(unsafeBitCast(swizzledSendEventBlock, to: AnyObject.self))
         originalIMP = method_setImplementation(originalMethod, swizzledIMP)
+        isActive = true
     }
     
     func stop() {
@@ -42,6 +43,7 @@ final class UIWindowSwizzleSource: UIEventSource, AnyObject {
         let originalIMP else { return }
         
         _ = method_setImplementation(method, originalIMP)
+        isActive = false
     }
 }
 

--- a/Sources/LaunchDarklyObservability/UIInteractions/UInteraction+Span.swift
+++ b/Sources/LaunchDarklyObservability/UIInteractions/UInteraction+Span.swift
@@ -10,6 +10,7 @@ enum ClickAttributes {
         tag: String?,
         text: String?,
         screenId: String?,
+        screenName: String? = nil,
         x: Int?,
         y: Int?,
         contextKeyAttributes: [String: AttributeValue] = [:],
@@ -35,6 +36,9 @@ enum ClickAttributes {
         if let screenId {
             attributes[SemanticConvention.eventScreenId] = .string(screenId)
         }
+        if let screenName {
+            attributes[SemanticConvention.eventScreenName] = .string(screenName)
+        }
         if let x {
             attributes[SemanticConvention.eventX] = .int(x)
         }
@@ -46,9 +50,12 @@ enum ClickAttributes {
 }
 
 extension TouchInteraction {
-    /// - Parameter screenId: The current screen's stable id (`event.screen_id`), when known,
-    ///   so the tap correlates with the active `screen_view`. Omitted from the span when `nil`.
-    func startEndSpan(tracer: Tracer, screenId: String? = nil) {
+    /// - Parameters:
+    ///   - screenId: The current screen's stable id (`event.screen_id`), when known, so the tap
+    ///     correlates with the active `screen_view`. Omitted from the span when `nil`.
+    ///   - screenName: The current screen's human-readable name (`event.screen_name`), when known.
+    ///     Omitted from the span when `nil`.
+    func startEndSpan(tracer: Tracer, screenId: String? = nil, screenName: String? = nil) {
         guard case let .touchUp(point) = kind else { return }
 
         // Per analytics-taxonomy §4.1 `click`: one event for all element types,
@@ -65,6 +72,9 @@ extension TouchInteraction {
         }
         if let screenId {
             attributes[SemanticConvention.eventScreenId] = .string(screenId)
+        }
+        if let screenName {
+            attributes[SemanticConvention.eventScreenName] = .string(screenName)
         }
         attributes[SemanticConvention.eventX] = .int(Int(point.x))
         attributes[SemanticConvention.eventY] = .int(Int(point.y))

--- a/Sources/LaunchDarklyObservability/UIInteractions/UInteraction+Span.swift
+++ b/Sources/LaunchDarklyObservability/UIInteractions/UInteraction+Span.swift
@@ -56,8 +56,9 @@ extension TouchInteraction {
         var attributes: [String: AttributeValue] = [:]
         attributes[SemanticConvention.eventType] = .string(SemanticConvention.clickSpanName)
         attributes[SemanticConvention.eventTag] = .string(target?.className ?? "unknown")
-        if let accessibilityIdentifier = target?.accessibilityIdentifier {
-            attributes[SemanticConvention.eventId] = .string(accessibilityIdentifier)
+        // Prefer an explicit `ldId(...)`; fall back to the accessibility identifier.
+        if let id = target?.ldId ?? target?.accessibilityIdentifier {
+            attributes[SemanticConvention.eventId] = .string(id)
         }
         if let text = target?.text {
             attributes[SemanticConvention.eventText] = .string(text)

--- a/Sources/LaunchDarklyObservability/UIInteractions/UInteraction+Span.swift
+++ b/Sources/LaunchDarklyObservability/UIInteractions/UInteraction+Span.swift
@@ -1,7 +1,54 @@
 import Foundation
 
+/// Builds the `event.*` attributes for a `click` span (taxonomy §4.1), shared by the manual
+/// `trackClick` API. Applied in increasing precedence so the taxonomy can never be clobbered:
+/// caller `properties` first, then `contextKeyAttributes`, then the reserved `event.*` fields
+/// last. Optional values are omitted when `nil`; `event.type` is always present.
+enum ClickAttributes {
+    static func build(
+        id: String?,
+        tag: String?,
+        text: String?,
+        screenId: String?,
+        x: Int?,
+        y: Int?,
+        contextKeyAttributes: [String: AttributeValue] = [:],
+        properties: [String: AttributeValue] = [:]
+    ) -> [String: AttributeValue] {
+        var attributes: [String: AttributeValue] = [:]
+        for (k, v) in properties {
+            attributes[k] = v
+        }
+        for (k, v) in contextKeyAttributes {
+            attributes[k] = v
+        }
+        attributes[SemanticConvention.eventType] = .string(SemanticConvention.clickSpanName)
+        if let tag {
+            attributes[SemanticConvention.eventTag] = .string(tag)
+        }
+        if let id {
+            attributes[SemanticConvention.eventId] = .string(id)
+        }
+        if let text {
+            attributes[SemanticConvention.eventText] = .string(text)
+        }
+        if let screenId {
+            attributes[SemanticConvention.eventScreenId] = .string(screenId)
+        }
+        if let x {
+            attributes[SemanticConvention.eventX] = .int(x)
+        }
+        if let y {
+            attributes[SemanticConvention.eventY] = .int(y)
+        }
+        return attributes
+    }
+}
+
 extension TouchInteraction {
-    func startEndSpan(tracer: Tracer) {
+    /// - Parameter screenId: The current screen's stable id (`event.screen_id`), when known,
+    ///   so the tap correlates with the active `screen_view`. Omitted from the span when `nil`.
+    func startEndSpan(tracer: Tracer, screenId: String? = nil) {
         guard case let .touchUp(point) = kind else { return }
 
         // Per analytics-taxonomy §4.1 `click`: one event for all element types,
@@ -14,6 +61,9 @@ extension TouchInteraction {
         }
         if let text = target?.text {
             attributes[SemanticConvention.eventText] = .string(text)
+        }
+        if let screenId {
+            attributes[SemanticConvention.eventScreenId] = .string(screenId)
         }
         attributes[SemanticConvention.eventX] = .int(Int(point.x))
         attributes[SemanticConvention.eventY] = .int(Int(point.y))

--- a/Sources/LaunchDarklyObservability/UIInteractions/UserInteractionManager.swift
+++ b/Sources/LaunchDarklyObservability/UIInteractions/UserInteractionManager.swift
@@ -28,15 +28,14 @@ public final class UserInteractionManager {
         let targetResolver = TargetResolver()
         self.inputCaptureCoordinator = InputCaptureCoordinator(
             targetResolver: targetResolver,
-            sessionIdProvider: sessionManaging.sessionIdProvider
+            sessionIdProvider: sessionManaging.sessionIdProvider,
+            // Resolve the screen on the main thread at touch-capture time (inside the coordinator), so
+            // it can't drift to a later screen by the time the background interpreter runs `onTouch`.
+            screenInfoProvider: screenInfoProvider
         )
         self.inputCaptureCoordinator.onTouch = { [interactionEventSubject] interaction in
-            // Stamp the live screen once, here in the single funnel both consumers read, so the OTel
-            // `click` span and the Session Replay click event always agree on the screen.
-            var interaction = interaction
-            let screen = screenInfoProvider()
-            interaction.screenId = screen.screenId
-            interaction.screenName = screen.screenName
+            // `interaction` already carries the screen captured on the main thread, so both the OTel
+            // `click` span and the Session Replay click event read the same, correct screen.
             yield(interaction)
             interactionEventSubject.send(.touch(interaction))
         }

--- a/Sources/LaunchDarklyObservability/UIInteractions/UserInteractionManager.swift
+++ b/Sources/LaunchDarklyObservability/UIInteractions/UserInteractionManager.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Combine
 
 #if !LD_COCOAPODS
@@ -7,6 +8,8 @@ import Combine
 public final class UserInteractionManager {
     private var inputCaptureCoordinator: InputCaptureCoordinator
     private let interactionEventSubject = PassthroughSubject<InteractionEvent, Never>()
+    private let startLock = NSLock()
+    private var isStarted = false
     
     /// Ordered stream of touches (``TouchInteraction``) and non-spatial ``PressInteraction``.
     public var interactionEvents: AnyPublisher<InteractionEvent, Never> {
@@ -28,7 +31,16 @@ public final class UserInteractionManager {
         }
     }
         
-    func start() {
+    /// Installs the touch-capture hook (swizzles `UIWindow.sendEvent`). Idempotent and
+    /// thread-safe, so it can be called by both the Observability tap instrumentation (gated
+    /// by ``ObservabilityOptions/Instrumentation/userTaps``) and by Session Replay, whichever
+    /// activates first. When neither needs it the hook is never installed.
+    public func start() {
+        startLock.lock()
+        let shouldStart = !isStarted
+        isStarted = true
+        startLock.unlock()
+        guard shouldStart else { return }
         inputCaptureCoordinator.start()
     }
     

--- a/Sources/LaunchDarklyObservability/UIInteractions/UserInteractionManager.swift
+++ b/Sources/LaunchDarklyObservability/UIInteractions/UserInteractionManager.swift
@@ -16,13 +16,27 @@ public final class UserInteractionManager {
         interactionEventSubject.eraseToAnyPublisher()
     }
     
-    init(options: ObservabilityOptions, sessionManaging: SessionManaging, yield: @escaping TouchInteractionYield) {
+    /// Resolves the active screen (`event.screen_id` / `event.screen_name`) at the instant of a tap.
+    public typealias ScreenInfoProvider = @Sendable () -> (screenId: String?, screenName: String?)
+
+    init(
+        options: ObservabilityOptions,
+        sessionManaging: SessionManaging,
+        screenInfoProvider: @escaping ScreenInfoProvider = { (nil, nil) },
+        yield: @escaping TouchInteractionYield
+    ) {
         let targetResolver = TargetResolver()
         self.inputCaptureCoordinator = InputCaptureCoordinator(
             targetResolver: targetResolver,
             sessionIdProvider: sessionManaging.sessionIdProvider
         )
         self.inputCaptureCoordinator.onTouch = { [interactionEventSubject] interaction in
+            // Stamp the live screen once, here in the single funnel both consumers read, so the OTel
+            // `click` span and the Session Replay click event always agree on the screen.
+            var interaction = interaction
+            let screen = screenInfoProvider()
+            interaction.screenId = screen.screenId
+            interaction.screenName = screen.screenName
             yield(interaction)
             interactionEventSubject.send(.touch(interaction))
         }

--- a/Sources/LaunchDarklySessionReplay/Exporter/RRWebEventGenerator.swift
+++ b/Sources/LaunchDarklySessionReplay/Exporter/RRWebEventGenerator.swift
@@ -53,9 +53,6 @@ actor RRWebEventGenerator {
     private var stats: SessionReplayStats?
     private let isDebug = false
     private var nodeIds: [ImageSignature: Int] = [:]
-    /// Name of the most recently navigated screen, stamped onto click events. The event queue is
-    /// ordered, so the `Navigate` for the active screen is always processed before its clicks.
-    private var currentScreenName: String?
     
     init(log: OSLog, title: String, method _: SessionReplayOptions.CompressionMethod) {
         if isDebug {
@@ -171,7 +168,6 @@ actor RRWebEventGenerator {
             }
             
         case let navigateItem as NavigateItemPayload:
-            currentScreenName = navigateItem.name
             events.append(navigateEvent(itemPayload: navigateItem))
             
         case let lifecycleItem as AppLifecycleItemPayload:
@@ -271,11 +267,13 @@ actor RRWebEventGenerator {
         // - clickTextContent: the element's visible text (web: `target.textContent`)
         // - clickSelector: simple selector (web: `#id` else tag; iOS analog: ldId else a11y id else class name)
         let target = interaction.target
+        // `screenName` is stamped onto the interaction at tap time from the live `ScreenStack`, the
+        // same source the OTel `click` span reads, so replay clicks never lag an export-time Navigate.
         let eventData = CustomEventData(tag: .click, payload: ClickPayload(
             clickTarget: target?.className ?? "",
             clickTextContent: target?.text ?? "",
             clickSelector: target?.ldId ?? target?.accessibilityIdentifier ?? target?.className ?? "view",
-            screenName: currentScreenName))
+            screenName: interaction.screenName))
         let event = Event(type: .Custom,
                           data: AnyEventData(eventData),
                           timestamp: interaction.timestamp,

--- a/Sources/LaunchDarklySessionReplay/Exporter/RRWebEventGenerator.swift
+++ b/Sources/LaunchDarklySessionReplay/Exporter/RRWebEventGenerator.swift
@@ -257,17 +257,20 @@ actor RRWebEventGenerator {
     }
     
     func clickEvent(interaction: TouchInteraction) -> Event? {
-        guard case .touchDown = interaction.kind else { return nil }
+        // Resolve on touch-up: the SwiftUI `.ldClick(_:)` tap gesture fires on release, so the
+        // developer-supplied `ldId` is only available on the touch-up target (matching the `click`
+        // span, which is also emitted on touch-up).
+        guard case .touchUp = interaction.kind else { return nil }
         
         // Mirror the web `Click` payload (`highlight-run` ClickListener):
         // - clickTarget: element identifier (web: full CSS selector path; iOS analog: class name)
         // - clickTextContent: the element's visible text (web: `target.textContent`)
-        // - clickSelector: simple selector (web: `#id` else tag; iOS analog: a11y id else class name)
+        // - clickSelector: simple selector (web: `#id` else tag; iOS analog: ldId else a11y id else class name)
         let target = interaction.target
         let eventData = CustomEventData(tag: .click, payload: ClickPayload(
             clickTarget: target?.className ?? "",
             clickTextContent: target?.text ?? "",
-            clickSelector: target?.accessibilityIdentifier ?? target?.className ?? "view"))
+            clickSelector: target?.ldId ?? target?.accessibilityIdentifier ?? target?.className ?? "view"))
         let event = Event(type: .Custom,
                           data: AnyEventData(eventData),
                           timestamp: interaction.timestamp,

--- a/Sources/LaunchDarklySessionReplay/Exporter/RRWebEventGenerator.swift
+++ b/Sources/LaunchDarklySessionReplay/Exporter/RRWebEventGenerator.swift
@@ -53,6 +53,9 @@ actor RRWebEventGenerator {
     private var stats: SessionReplayStats?
     private let isDebug = false
     private var nodeIds: [ImageSignature: Int] = [:]
+    /// Name of the most recently navigated screen, stamped onto click events. The event queue is
+    /// ordered, so the `Navigate` for the active screen is always processed before its clicks.
+    private var currentScreenName: String?
     
     init(log: OSLog, title: String, method _: SessionReplayOptions.CompressionMethod) {
         if isDebug {
@@ -168,6 +171,7 @@ actor RRWebEventGenerator {
             }
             
         case let navigateItem as NavigateItemPayload:
+            currentScreenName = navigateItem.name
             events.append(navigateEvent(itemPayload: navigateItem))
             
         case let lifecycleItem as AppLifecycleItemPayload:
@@ -270,7 +274,8 @@ actor RRWebEventGenerator {
         let eventData = CustomEventData(tag: .click, payload: ClickPayload(
             clickTarget: target?.className ?? "",
             clickTextContent: target?.text ?? "",
-            clickSelector: target?.ldId ?? target?.accessibilityIdentifier ?? target?.className ?? "view"))
+            clickSelector: target?.ldId ?? target?.accessibilityIdentifier ?? target?.className ?? "view",
+            screenName: currentScreenName))
         let event = Event(type: .Custom,
                           data: AnyEventData(eventData),
                           timestamp: interaction.timestamp,

--- a/Sources/LaunchDarklySessionReplay/Exporter/RRWebEventGenerator.swift
+++ b/Sources/LaunchDarklySessionReplay/Exporter/RRWebEventGenerator.swift
@@ -267,12 +267,14 @@ actor RRWebEventGenerator {
         // - clickTextContent: the element's visible text (web: `target.textContent`)
         // - clickSelector: simple selector (web: `#id` else tag; iOS analog: ldId else a11y id else class name)
         let target = interaction.target
-        // `screenName` is stamped onto the interaction at tap time from the live `ScreenStack`, the
-        // same source the OTel `click` span reads, so replay clicks never lag an export-time Navigate.
+        // `screenId`/`screenName` are stamped onto the interaction at tap time from the live
+        // `ScreenStack`, the same source the OTel `click` span and manual `trackClick` read, so replay
+        // clicks correlate to the same stable screen and never lag an export-time Navigate.
         let eventData = CustomEventData(tag: .click, payload: ClickPayload(
             clickTarget: target?.className ?? "",
             clickTextContent: target?.text ?? "",
             clickSelector: target?.ldId ?? target?.accessibilityIdentifier ?? target?.className ?? "view",
+            screenId: interaction.screenId,
             screenName: interaction.screenName))
         let event = Event(type: .Custom,
                           data: AnyEventData(eventData),

--- a/Sources/LaunchDarklySessionReplay/RRWeb/CustomEventData.swift
+++ b/Sources/LaunchDarklySessionReplay/RRWeb/CustomEventData.swift
@@ -19,6 +19,9 @@ struct ClickPayload: Codable {
     var clickTarget: String
     var clickTextContent: String
     var clickSelector: String
+    /// Human-readable name of the screen active when the click happened (`event.screen_name`
+    /// analog), sourced from the most recent `Navigate` event. Omitted when unknown.
+    var screenName: String?
 }
 
 /// Mirrors the web `Track` custom-event payload (`{ ...metadata, event }`) emitted by

--- a/Sources/LaunchDarklySessionReplay/RRWeb/CustomEventData.swift
+++ b/Sources/LaunchDarklySessionReplay/RRWeb/CustomEventData.swift
@@ -19,8 +19,14 @@ struct ClickPayload: Codable {
     var clickTarget: String
     var clickTextContent: String
     var clickSelector: String
+    /// Stable id of the screen active when the click happened (`event.screen_id` analog), stamped
+    /// onto the interaction at tap time from the shared `ScreenStack`. Matches the id carried by the
+    /// OpenTelemetry `click` span and manual `trackClick`, so replay clicks correlate to the same
+    /// screen. Omitted when unknown.
+    var screenId: String?
     /// Human-readable name of the screen active when the click happened (`event.screen_name`
-    /// analog), sourced from the most recent `Navigate` event. Omitted when unknown.
+    /// analog), stamped onto the interaction at tap time from the shared `ScreenStack`. Omitted when
+    /// unknown.
     var screenName: String?
 }
 

--- a/Sources/LaunchDarklySessionReplay/SessionReplayService.swift
+++ b/Sources/LaunchDarklySessionReplay/SessionReplayService.swift
@@ -239,6 +239,11 @@ final class SessionReplayService: SessionReplayServicing {
     
     @MainActor
     private func internalStart() {
+        // Session Replay needs the touch stream regardless of `instrumentation.userTaps`. The
+        // capture hook is shared with Observability and idempotent, so start it here too: if tap
+        // detection already started it this is a no-op, otherwise SR installs it on its own.
+        userInteractionManager.start()
+
         userInteractionManager.interactionEvents
             .sink { [transportService] event in
                 Task {

--- a/TestApp/Sources/AppDelegate.swift
+++ b/TestApp/Sources/AppDelegate.swift
@@ -15,6 +15,36 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
         }
         let otlpEndpoint = secrets["otlpEndpoint"] as? String
         let backendUrl = secrets["backendUrl"] as? String
+//        let config = { () -> LDConfig in
+//            var config = LDConfig(
+//                    mobileKey: mobileKey,
+//                    autoEnvAttributes: .enabled
+//                )
+//            config.plugins = [
+//                Observability(options: .init(
+//                    isEnabled: true,
+//                    serviceName: "observability-ios-test-app",
+//                    otlpEndpoint: otlpEndpoint,
+//                    backendUrl: backendUrl,
+//                    resourceAttributes: ["test-options-attribute": .string("ios-test-app")],
+//                    sessionBackgroundTimeout: 3,
+//                    crashReporting: .enabled
+//                   )),
+//                SessionReplay(options: .init(
+//                    isEnabled: true,
+//                    privacy: .init(
+//                        maskTextInputs: true,
+//                        maskWebViews: true,
+//                        maskLabels: false,
+//                        maskImages: false,
+//                        maskAccessibilityIdentifiers: ["email-field", "password-field", "card-brand-chip", "10"],
+//                    )
+//                ))
+//            ]
+//            
+//            return config
+//        }()
+//        
         let config = { () -> LDConfig in
             var config = LDConfig(
                     mobileKey: mobileKey,
@@ -24,26 +54,12 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
                 Observability(options: .init(
                     isEnabled: true,
                     serviceName: "observability-ios-test-app",
-                    otlpEndpoint: otlpEndpoint,
-                    backendUrl: backendUrl,
-                    resourceAttributes: ["test-options-attribute": .string("ios-test-app")],
-                    sessionBackgroundTimeout: 3,
-                    crashReporting: .enabled
+                    instrumentation: .disabled,
                    )),
-                SessionReplay(options: .init(
-                    isEnabled: true,
-                    privacy: .init(
-                        maskTextInputs: true,
-                        maskWebViews: true,
-                        maskLabels: false,
-                        maskImages: false,
-                        maskAccessibilityIdentifiers: ["email-field", "password-field", "card-brand-chip", "10"],
-                    )
-                ))
             ]
-            
             return config
         }()
+        
         let context = { () -> LDContext in
             var contextBuilder = LDContextBuilder(
                 key: "12345"

--- a/TestApp/Sources/AppDelegate.swift
+++ b/TestApp/Sources/AppDelegate.swift
@@ -30,16 +30,16 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
                     sessionBackgroundTimeout: 3,
                     crashReporting: .enabled
                    )),
-                SessionReplay(options: .init(
-                    isEnabled: true,
-                    privacy: .init(
-                        maskTextInputs: true,
-                        maskWebViews: true,
-                        maskLabels: false,
-                        maskImages: false,
-                        maskAccessibilityIdentifiers: ["email-field", "password-field", "card-brand-chip", "10"],
-                    )
-                ))
+//                SessionReplay(options: .init(
+//                    isEnabled: true,
+//                    privacy: .init(
+//                        maskTextInputs: true,
+//                        maskWebViews: true,
+//                        maskLabels: false,
+//                        maskImages: false,
+//                        maskAccessibilityIdentifiers: ["email-field", "password-field", "card-brand-chip", "10"],
+//                    )
+//                ))
             ]
             
             return config

--- a/TestApp/Sources/AppDelegate.swift
+++ b/TestApp/Sources/AppDelegate.swift
@@ -15,36 +15,6 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
         }
         let otlpEndpoint = secrets["otlpEndpoint"] as? String
         let backendUrl = secrets["backendUrl"] as? String
-//        let config = { () -> LDConfig in
-//            var config = LDConfig(
-//                    mobileKey: mobileKey,
-//                    autoEnvAttributes: .enabled
-//                )
-//            config.plugins = [
-//                Observability(options: .init(
-//                    isEnabled: true,
-//                    serviceName: "observability-ios-test-app",
-//                    otlpEndpoint: otlpEndpoint,
-//                    backendUrl: backendUrl,
-//                    resourceAttributes: ["test-options-attribute": .string("ios-test-app")],
-//                    sessionBackgroundTimeout: 3,
-//                    crashReporting: .enabled
-//                   )),
-//                SessionReplay(options: .init(
-//                    isEnabled: true,
-//                    privacy: .init(
-//                        maskTextInputs: true,
-//                        maskWebViews: true,
-//                        maskLabels: false,
-//                        maskImages: false,
-//                        maskAccessibilityIdentifiers: ["email-field", "password-field", "card-brand-chip", "10"],
-//                    )
-//                ))
-//            ]
-//            
-//            return config
-//        }()
-//        
         let config = { () -> LDConfig in
             var config = LDConfig(
                     mobileKey: mobileKey,
@@ -54,11 +24,41 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
                 Observability(options: .init(
                     isEnabled: true,
                     serviceName: "observability-ios-test-app",
-                    instrumentation: .disabled,
+                    otlpEndpoint: otlpEndpoint,
+                    backendUrl: backendUrl,
+                    resourceAttributes: ["test-options-attribute": .string("ios-test-app")],
+                    sessionBackgroundTimeout: 3,
+                    crashReporting: .enabled
                    )),
+                SessionReplay(options: .init(
+                    isEnabled: true,
+                    privacy: .init(
+                        maskTextInputs: true,
+                        maskWebViews: true,
+                        maskLabels: false,
+                        maskImages: false,
+                        maskAccessibilityIdentifiers: ["email-field", "password-field", "card-brand-chip", "10"],
+                    )
+                ))
             ]
+            
             return config
         }()
+//        
+//        let config = { () -> LDConfig in
+//            var config = LDConfig(
+//                    mobileKey: mobileKey,
+//                    autoEnvAttributes: .enabled
+//                )
+//            config.plugins = [
+//                Observability(options: .init(
+//                    isEnabled: true,
+//                    serviceName: "observability-ios-test-app",
+//                    instrumentation: .disabled,
+//                   )),
+//            ]
+//            return config
+//        }()
         
         let context = { () -> LDContext in
             var contextBuilder = LDContextBuilder(

--- a/TestApp/Sources/AppDelegate.swift
+++ b/TestApp/Sources/AppDelegate.swift
@@ -30,16 +30,16 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
                     sessionBackgroundTimeout: 3,
                     crashReporting: .enabled
                    )),
-//                SessionReplay(options: .init(
-//                    isEnabled: true,
-//                    privacy: .init(
-//                        maskTextInputs: true,
-//                        maskWebViews: true,
-//                        maskLabels: false,
-//                        maskImages: false,
-//                        maskAccessibilityIdentifiers: ["email-field", "password-field", "card-brand-chip", "10"],
-//                    )
-//                ))
+                SessionReplay(options: .init(
+                    isEnabled: true,
+                    privacy: .init(
+                        maskTextInputs: true,
+                        maskWebViews: true,
+                        maskLabels: false,
+                        maskImages: false,
+                        maskAccessibilityIdentifiers: ["email-field", "password-field", "card-brand-chip", "10"],
+                    )
+                ))
             ]
             
             return config

--- a/TestApp/Sources/MainMenuView.swift
+++ b/TestApp/Sources/MainMenuView.swift
@@ -133,6 +133,7 @@ struct MainMenuView: View {
                 Button("Drawing") {
                     activeSheet = .notebook
                 }
+                .accessibilityIdentifier("a-drawing")
                 .buttonStyle(.borderedProminent)
 #endif
 
@@ -179,6 +180,7 @@ struct MainMenuView: View {
                 }
                 .buttonStyle(.borderedProminent)
                 .tint(Colors.identifyBgColor)
+                .ldClick("identify.user")
 
                 Button {
                     viewModel.identifyMulti()
@@ -187,6 +189,7 @@ struct MainMenuView: View {
                 }
                 .buttonStyle(.borderedProminent)
                 .tint(Colors.identifyBgColor)
+                .ldClick("identify.multi")
 
                 Button {
                     viewModel.identifyAnonymous()
@@ -195,6 +198,7 @@ struct MainMenuView: View {
                 }
                 .buttonStyle(.borderedProminent)
                 .tint(Colors.identifyBgColor)
+                .ldClick("identify.anonymous")
             }
 
             Text("Instrumentation")
@@ -216,6 +220,7 @@ struct MainMenuView: View {
                 }
                 .buttonStyle(.borderedProminent)
                 .disabled(viewModel.isNetworkInProgress)
+                .ldClick("instrumentation.network_request")
 
                 Button {
                     viewModel.crash()
@@ -224,6 +229,7 @@ struct MainMenuView: View {
                 }
                 .buttonStyle(.borderedProminent)
                 .tint(.red)
+                .ldClick("instrumentation.crash")
             }
 
 #if os(iOS)
@@ -238,16 +244,21 @@ struct MainMenuView: View {
             HStack {
                 Button("Metric") { viewModel.recordMetric() }
                     .buttonStyle(.borderedProminent)
+                    .ldClick("metric.gauge")
                 Button("Histogram") { viewModel.recordHistogramMetric() }
                     .buttonStyle(.borderedProminent)
+                    .ldClick("metric.histogram")
                 Button("Count") { viewModel.recordCounterMetric() }
                     .buttonStyle(.borderedProminent)
+                    .ldClick("metric.count")
             }
             HStack {
                 Button("Incremental") { viewModel.recordIncrementalMetric() }
                     .buttonStyle(.borderedProminent)
+                    .ldClick("metric.incremental")
                 Button("UpDownCounter") { viewModel.recordUpDownCounterMetric() }
                     .buttonStyle(.borderedProminent)
+                    .ldClick("metric.up_down_counter")
             }
 
             Text("Track")
@@ -256,14 +267,18 @@ struct MainMenuView: View {
             HStack {
                 Button("Track (LDClient)") { viewModel.trackViaLDClient() }
                     .buttonStyle(.borderedProminent)
+                    .ldClick("track.ld_client")
                 Button("Track (LDObserve)") { viewModel.trackViaLDObserve() }
                     .buttonStyle(.borderedProminent)
+                    .ldClick("track.ld_observe")
             }
             HStack {
                 Button("Track Screen View") { viewModel.trackScreenView() }
                     .buttonStyle(.borderedProminent)
+                    .ldClick("track.screen_view")
                 Button("Track (Nested)") { viewModel.trackNested() }
                     .buttonStyle(.borderedProminent)
+                    .ldClick("track.nested")
             }
 
             Text("Error")
@@ -276,6 +291,7 @@ struct MainMenuView: View {
             }
             .buttonStyle(.borderedProminent)
             .tint(.red)
+            .ldClick("error.trigger")
 
             Text("Logs")
                 .fontWeight(.bold)
@@ -287,6 +303,7 @@ struct MainMenuView: View {
                     Text("Log")
                 }
                 .buttonStyle(.borderedProminent)
+                .ldClick("logs.log")
 
                 Button {
                     viewModel.recordLogWithContext()
@@ -294,6 +311,7 @@ struct MainMenuView: View {
                     Text("Log with Context")
                 }
                 .buttonStyle(.borderedProminent)
+                .ldClick("logs.log_with_context")
             }
 
             Text("Traces")
@@ -306,6 +324,7 @@ struct MainMenuView: View {
                     Text("Span & Flag Eval")
                 }
                 .buttonStyle(.borderedProminent)
+                .ldClick("traces.span_and_flag_eval")
 
                 Button {
                     viewModel.triggerNestedSpans()
@@ -313,6 +332,7 @@ struct MainMenuView: View {
                     Text("Nested Spans")
                 }
                 .buttonStyle(.borderedProminent)
+                .ldClick("traces.nested_spans")
             }
         }
     }

--- a/Tests/ObservabilityTests/Transport/FlushableWorkerTests.swift
+++ b/Tests/ObservabilityTests/Transport/FlushableWorkerTests.swift
@@ -20,6 +20,26 @@ struct FlushableWorkerTests {
             events.filter { !$0.isFlush }.count
         }
     }
+
+    /// A one-shot gate: `wait()` suspends until `open()` is called (and returns immediately
+    /// thereafter). Used to hold a unit of work in-flight so a test can deterministically observe
+    /// behaviour that depends on work still being pending.
+    actor Gate {
+        private var isOpen = false
+        private var waiters: [CheckedContinuation<Void, Never>] = []
+
+        func wait() async {
+            if isOpen { return }
+            await withCheckedContinuation { waiters.append($0) }
+        }
+
+        func open() {
+            isOpen = true
+            let pending = waiters
+            waiters.removeAll()
+            pending.forEach { $0.resume() }
+        }
+    }
     
     @Test
     func ticksOccurOnInterval() async throws {
@@ -66,15 +86,21 @@ struct FlushableWorkerTests {
     @Test
     func multipleFlushesCoalesceWhilePending() async throws {
         let recorder = Recorder()
+        // Gate the flush work so the first flush stays in-flight (its pending flag uncleared) until
+        // the test releases it. That's the precondition for coalescing: without the gate the trivial
+        // work can finish - clearing the pending flag - before the second flush is issued, which is a
+        // legitimate non-coalesced outcome and is what made this test flaky under load.
+        let gate = Gate()
         let worker = FlushableWorker(interval: 10.0) { isFlushing in
             await recorder.add(isFlushing)
+            if isFlushing { await gate.wait() }
         }
         
         await worker.start()
         
-        try await Task.sleep(nanoseconds: NSEC_PER_SEC) // allow processing
         await worker.flush()
         await worker.flush() // second flush while first is pending should coalesce
+        await gate.open()     // release the first flush now that the second has been issued
         try await Task.sleep(nanoseconds: NSEC_PER_SEC)
         await worker.stop()
         

--- a/Tests/ObservabilityTests/UIInteractions/ClickAttributesTests.swift
+++ b/Tests/ObservabilityTests/UIInteractions/ClickAttributesTests.swift
@@ -1,0 +1,90 @@
+import Testing
+import OpenTelemetryApi
+@testable import LaunchDarklyObservability
+
+/// Unit tests for the shared `click` attribute builder used by the manual `trackClick` API
+/// (taxonomy §4.1).
+struct ClickAttributesTests {
+    @Test("manual click shape includes the supplied event.* fields")
+    func includesSuppliedFields() {
+        let attrs = ClickAttributes.build(
+            id: "paywall.primary_cta",
+            tag: "UIButton",
+            text: "Continue",
+            screenId: "MyApp.PaywallViewController",
+            x: 120,
+            y: 818
+        )
+
+        #expect(attrs[SemanticConvention.eventType] == .string("click"))
+        #expect(attrs[SemanticConvention.eventTag] == .string("UIButton"))
+        #expect(attrs[SemanticConvention.eventId] == .string("paywall.primary_cta"))
+        #expect(attrs[SemanticConvention.eventText] == .string("Continue"))
+        #expect(attrs[SemanticConvention.eventScreenId] == .string("MyApp.PaywallViewController"))
+        #expect(attrs[SemanticConvention.eventX] == .int(120))
+        #expect(attrs[SemanticConvention.eventY] == .int(818))
+    }
+
+    @Test("optional fields are omitted when nil")
+    func omitsNilFields() {
+        let attrs = ClickAttributes.build(
+            id: nil,
+            tag: nil,
+            text: nil,
+            screenId: nil,
+            x: nil,
+            y: nil
+        )
+
+        // event.type is always present; everything else is omitted.
+        #expect(attrs[SemanticConvention.eventType] == .string("click"))
+        #expect(attrs[SemanticConvention.eventTag] == nil)
+        #expect(attrs[SemanticConvention.eventId] == nil)
+        #expect(attrs[SemanticConvention.eventText] == nil)
+        #expect(attrs[SemanticConvention.eventScreenId] == nil)
+        #expect(attrs[SemanticConvention.eventX] == nil)
+        #expect(attrs[SemanticConvention.eventY] == nil)
+    }
+
+    @Test("reserved event.* fields win over caller properties")
+    func reservedFieldsWin() {
+        let properties: [String: AttributeValue] = [
+            SemanticConvention.eventId: .string("from_properties"),
+            SemanticConvention.eventType: .string("not_click"),
+            "custom": .string("kept")
+        ]
+
+        let attrs = ClickAttributes.build(
+            id: "reserved_id",
+            tag: nil,
+            text: nil,
+            screenId: nil,
+            x: nil,
+            y: nil,
+            properties: properties
+        )
+
+        #expect(attrs[SemanticConvention.eventId] == .string("reserved_id"))
+        #expect(attrs[SemanticConvention.eventType] == .string("click"))
+        #expect(attrs["custom"] == .string("kept"))
+    }
+
+    @Test("context keys win over caller properties")
+    func contextKeysWinOverProperties() {
+        let properties: [String: AttributeValue] = ["accountId": .string("from_properties")]
+        let contextKeys: [String: AttributeValue] = ["accountId": .string("from_context")]
+
+        let attrs = ClickAttributes.build(
+            id: nil,
+            tag: nil,
+            text: nil,
+            screenId: nil,
+            x: nil,
+            y: nil,
+            contextKeyAttributes: contextKeys,
+            properties: properties
+        )
+
+        #expect(attrs["accountId"] == .string("from_context"))
+    }
+}

--- a/Tests/ObservabilityTests/UIInteractions/ClickSpanTests.swift
+++ b/Tests/ObservabilityTests/UIInteractions/ClickSpanTests.swift
@@ -134,6 +134,66 @@ struct ClickSpanTests {
         #expect(span.attributes[SemanticConvention.eventScreenId] == nil)
     }
 
+    @Test("click span prefers ldId over accessibilityIdentifier for event.id")
+    func clickSpanPrefersLdId() {
+        let (tracer, processor) = makeTracer()
+        let target = TouchTarget(
+            className: "UIButton",
+            accessibilityIdentifier: "save_profile_btn",
+            ldId: "profile.save",
+            text: "Save",
+            isAccessibilityElement: true,
+            rectInWindow: .zero,
+            rectOnScreen: .zero,
+            rowIndex: nil,
+            sceneId: nil
+        )
+        let interaction = TouchInteraction(
+            id: 6,
+            kind: .touchUp(CGPoint(x: 1, y: 2)),
+            startTimestamp: 6000,
+            timestamp: 6001,
+            target: target,
+            sessionId: "session-6"
+        )
+
+        interaction.startEndSpan(tracer: tracer)
+
+        #expect(processor.ended.count == 1)
+        let span = processor.ended[0]
+        #expect(span.attributes[SemanticConvention.eventId] == .string("profile.save"))
+    }
+
+    @Test("click span falls back to accessibilityIdentifier when ldId is absent")
+    func clickSpanFallsBackToAccessibilityIdentifier() {
+        let (tracer, processor) = makeTracer()
+        let target = TouchTarget(
+            className: "UIButton",
+            accessibilityIdentifier: "save_profile_btn",
+            ldId: nil,
+            text: "Save",
+            isAccessibilityElement: true,
+            rectInWindow: .zero,
+            rectOnScreen: .zero,
+            rowIndex: nil,
+            sceneId: nil
+        )
+        let interaction = TouchInteraction(
+            id: 7,
+            kind: .touchUp(CGPoint(x: 1, y: 2)),
+            startTimestamp: 7000,
+            timestamp: 7001,
+            target: target,
+            sessionId: "session-7"
+        )
+
+        interaction.startEndSpan(tracer: tracer)
+
+        #expect(processor.ended.count == 1)
+        let span = processor.ended[0]
+        #expect(span.attributes[SemanticConvention.eventId] == .string("save_profile_btn"))
+    }
+
     @Test("non-tap interactions do not emit a click span")
     func nonTapInteractionEmitsNothing() {
         let (tracer, processor) = makeTracer()

--- a/Tests/ObservabilityTests/UIInteractions/ClickSpanTests.swift
+++ b/Tests/ObservabilityTests/UIInteractions/ClickSpanTests.swift
@@ -106,16 +106,17 @@ struct ClickSpanTests {
             sessionId: "session-4"
         )
 
-        interaction.startEndSpan(tracer: tracer, screenId: "MyApp.MainTabViewController")
+        interaction.startEndSpan(tracer: tracer, screenId: "MyApp.MainTabViewController", screenName: "Home")
 
         #expect(processor.ended.count == 1)
         let span = processor.ended[0]
         #expect(span.attributes[SemanticConvention.eventScreenId] == .string("MyApp.MainTabViewController"))
+        #expect(span.attributes[SemanticConvention.eventScreenName] == .string("Home"))
         #expect(span.attributes[SemanticConvention.eventId] == .string("tab.search"))
         #expect(span.attributes[SemanticConvention.eventTag] == .string("UITabBarButton"))
     }
 
-    @Test("click span omits event.screen_id when no current screen is known")
+    @Test("click span omits event.screen_id and event.screen_name when no current screen is known")
     func clickSpanOmitsScreenId() {
         let (tracer, processor) = makeTracer()
         let interaction = TouchInteraction(
@@ -127,11 +128,12 @@ struct ClickSpanTests {
             sessionId: "session-5"
         )
 
-        interaction.startEndSpan(tracer: tracer, screenId: nil)
+        interaction.startEndSpan(tracer: tracer, screenId: nil, screenName: nil)
 
         #expect(processor.ended.count == 1)
         let span = processor.ended[0]
         #expect(span.attributes[SemanticConvention.eventScreenId] == nil)
+        #expect(span.attributes[SemanticConvention.eventScreenName] == nil)
     }
 
     @Test("click span prefers ldId over accessibilityIdentifier for event.id")

--- a/Tests/ObservabilityTests/UIInteractions/ClickSpanTests.swift
+++ b/Tests/ObservabilityTests/UIInteractions/ClickSpanTests.swift
@@ -84,6 +84,56 @@ struct ClickSpanTests {
         #expect(span.attributes[SemanticConvention.eventY] == .int(6))
     }
 
+    @Test("click span includes event.screen_id when a current screen is known")
+    func clickSpanIncludesScreenId() {
+        let (tracer, processor) = makeTracer()
+        let target = TouchTarget(
+            className: "UITabBarButton",
+            accessibilityIdentifier: "tab.search",
+            text: "Search and Explore",
+            isAccessibilityElement: true,
+            rectInWindow: .zero,
+            rectOnScreen: .zero,
+            rowIndex: nil,
+            sceneId: nil
+        )
+        let interaction = TouchInteraction(
+            id: 4,
+            kind: .touchUp(CGPoint(x: 120, y: 818)),
+            startTimestamp: 4000,
+            timestamp: 4001,
+            target: target,
+            sessionId: "session-4"
+        )
+
+        interaction.startEndSpan(tracer: tracer, screenId: "MyApp.MainTabViewController")
+
+        #expect(processor.ended.count == 1)
+        let span = processor.ended[0]
+        #expect(span.attributes[SemanticConvention.eventScreenId] == .string("MyApp.MainTabViewController"))
+        #expect(span.attributes[SemanticConvention.eventId] == .string("tab.search"))
+        #expect(span.attributes[SemanticConvention.eventTag] == .string("UITabBarButton"))
+    }
+
+    @Test("click span omits event.screen_id when no current screen is known")
+    func clickSpanOmitsScreenId() {
+        let (tracer, processor) = makeTracer()
+        let interaction = TouchInteraction(
+            id: 5,
+            kind: .touchUp(CGPoint(x: 1, y: 2)),
+            startTimestamp: 5000,
+            timestamp: 5001,
+            target: nil,
+            sessionId: "session-5"
+        )
+
+        interaction.startEndSpan(tracer: tracer, screenId: nil)
+
+        #expect(processor.ended.count == 1)
+        let span = processor.ended[0]
+        #expect(span.attributes[SemanticConvention.eventScreenId] == nil)
+    }
+
     @Test("non-tap interactions do not emit a click span")
     func nonTapInteractionEmitsNothing() {
         let (tracer, processor) = makeTracer()

--- a/Tests/ObservabilityTests/UIInteractions/LdClickRegistryTests.swift
+++ b/Tests/ObservabilityTests/UIInteractions/LdClickRegistryTests.swift
@@ -57,6 +57,24 @@ struct LdClickRegistryTests {
         #expect(registry.locationlessId() == nil)
     }
 
+    @Test("id matches when any candidate point is within tolerance")
+    func matchesAnyCandidatePoint() {
+        let registry = LdClickRegistry()
+        // Recorded in `.global` (here screen-relative); the window point won't match but the
+        // screen-converted candidate will.
+        registry.record(id: "pay", location: CGPoint(x: 300, y: 400))
+        let windowPoint = CGPoint(x: 100, y: 200)
+        let screenPoint = CGPoint(x: 300, y: 400)
+        #expect(registry.id(atAnyOf: [windowPoint, screenPoint]) == "pay")
+    }
+
+    @Test("id returns nil when no candidate point is within tolerance")
+    func noCandidatePointMatches() {
+        let registry = LdClickRegistry()
+        registry.record(id: "pay", location: CGPoint(x: 300, y: 400))
+        #expect(registry.id(atAnyOf: [CGPoint(x: 0, y: 0), CGPoint(x: 50, y: 50)]) == nil)
+    }
+
     @Test("the most recent matching entry wins")
     func mostRecentWins() {
         let registry = LdClickRegistry()

--- a/Tests/ObservabilityTests/UIInteractions/LdClickRegistryTests.swift
+++ b/Tests/ObservabilityTests/UIInteractions/LdClickRegistryTests.swift
@@ -1,0 +1,59 @@
+#if canImport(UIKit)
+import UIKit
+import Testing
+@testable import LaunchDarklyObservability
+
+@MainActor
+struct LdClickRegistryTests {
+    @Test("id returns the id recorded at a matching location")
+    func returnsMatchingLocation() {
+        let registry = LdClickRegistry()
+        registry.record(id: "checkout.pay_button", location: CGPoint(x: 100, y: 200))
+        #expect(registry.id(at: CGPoint(x: 100, y: 200)) == "checkout.pay_button")
+    }
+
+    @Test("id tolerates small location differences")
+    func returnsWithinTolerance() {
+        let registry = LdClickRegistry()
+        registry.record(id: "id", location: CGPoint(x: 100, y: 100))
+        #expect(registry.id(at: CGPoint(x: 110, y: 92)) == "id")
+    }
+
+    @Test("id ignores entries far from the touch point")
+    func ignoresFarLocation() {
+        let registry = LdClickRegistry()
+        registry.record(id: "id", location: CGPoint(x: 100, y: 100))
+        #expect(registry.id(at: CGPoint(x: 500, y: 500)) == nil)
+    }
+
+    @Test("lookup is non-consuming so multiple pipelines can read the same tap")
+    func lookupIsNonConsuming() {
+        let registry = LdClickRegistry()
+        registry.record(id: "id", location: CGPoint(x: 10, y: 10))
+        #expect(registry.id(at: CGPoint(x: 10, y: 10)) == "id")
+        #expect(registry.id(at: CGPoint(x: 10, y: 10)) == "id")
+    }
+
+    @Test("entries without a location match on recency")
+    func matchesLocationlessEntry() {
+        let registry = LdClickRegistry()
+        registry.record(id: "id", location: nil)
+        #expect(registry.id(at: CGPoint(x: 42, y: 42)) == "id")
+    }
+
+    @Test("the most recent matching entry wins")
+    func mostRecentWins() {
+        let registry = LdClickRegistry()
+        registry.record(id: "old", location: CGPoint(x: 50, y: 50))
+        registry.record(id: "new", location: CGPoint(x: 50, y: 50))
+        #expect(registry.id(at: CGPoint(x: 50, y: 50)) == "new")
+    }
+
+    @Test("an empty id is ignored")
+    func ignoresEmptyId() {
+        let registry = LdClickRegistry()
+        registry.record(id: "", location: CGPoint(x: 1, y: 1))
+        #expect(registry.id(at: CGPoint(x: 1, y: 1)) == nil)
+    }
+}
+#endif

--- a/Tests/ObservabilityTests/UIInteractions/LdClickRegistryTests.swift
+++ b/Tests/ObservabilityTests/UIInteractions/LdClickRegistryTests.swift
@@ -34,11 +34,27 @@ struct LdClickRegistryTests {
         #expect(registry.id(at: CGPoint(x: 10, y: 10)) == "id")
     }
 
-    @Test("entries without a location match on recency")
-    func matchesLocationlessEntry() {
+    @Test("a locationless entry never matches an arbitrary point via id(at:)")
+    func locationlessEntryDoesNotMatchByPoint() {
         let registry = LdClickRegistry()
         registry.record(id: "id", location: nil)
-        #expect(registry.id(at: CGPoint(x: 42, y: 42)) == "id")
+        // A locationless entry must not be returned for a geometric lookup, otherwise a later
+        // tap elsewhere could inherit it.
+        #expect(registry.id(at: CGPoint(x: 42, y: 42)) == nil)
+    }
+
+    @Test("a fresh locationless entry is returned by locationlessId")
+    func freshLocationlessEntryMatches() {
+        let registry = LdClickRegistry()
+        registry.record(id: "id", location: nil)
+        #expect(registry.locationlessId() == "id")
+    }
+
+    @Test("a located entry is not returned by locationlessId")
+    func locatedEntryNotReturnedByLocationless() {
+        let registry = LdClickRegistry()
+        registry.record(id: "id", location: CGPoint(x: 10, y: 10))
+        #expect(registry.locationlessId() == nil)
     }
 
     @Test("the most recent matching entry wins")

--- a/Tests/ObservabilityTests/UIInteractions/LdIdStorageTests.swift
+++ b/Tests/ObservabilityTests/UIInteractions/LdIdStorageTests.swift
@@ -1,0 +1,29 @@
+#if canImport(UIKit)
+import UIKit
+import Testing
+@testable import LaunchDarklyObservability
+
+@MainActor
+struct LdIdStorageTests {
+    @Test("UIView.ldId stores a value retrievable from LdIdStorage")
+    func uiViewLdIdStoresValue() {
+        let view = UIView()
+        view.ldId("checkout.pay_button")
+        #expect(LdIdStorage.get(view) == "checkout.pay_button")
+    }
+
+    @Test("LdIdStorage returns nil for an untagged view")
+    func untaggedViewReturnsNil() {
+        let view = UIView()
+        #expect(LdIdStorage.get(view) == nil)
+    }
+
+    @Test("UIView.ldId overwrites a previously stored value")
+    func uiViewLdIdOverwrites() {
+        let view = UIView()
+        view.ldId("first")
+        view.ldId("second")
+        #expect(LdIdStorage.get(view) == "second")
+    }
+}
+#endif

--- a/Tests/ObservabilityTests/UIInteractions/ScreenStackTests.swift
+++ b/Tests/ObservabilityTests/UIInteractions/ScreenStackTests.swift
@@ -69,6 +69,32 @@ struct ScreenStackTests {
         #expect(stack.snapshot == ["Detail"])
     }
 
+    @Test("Re-recording the top with the same id refreshes its display name")
+    func reappearanceRefreshesName() {
+        let stack = ScreenStack()
+        _ = stack.record("Home", id: "home")
+        _ = stack.record("Detail", id: "item-1")
+        // Same id re-appears with an updated display name; history stays stable but
+        // `current` must reflect the latest name, not the stale one.
+        #expect(stack.record("Detail Updated", id: "item-1") == "Home")
+        #expect(stack.current == "Detail Updated")
+        #expect(stack.currentId == "item-1")
+        #expect(stack.snapshot == ["Home", "Detail Updated"])
+    }
+
+    @Test("Pop-back refreshes the matched screen's display name")
+    func popBackRefreshesName() {
+        let stack = ScreenStack()
+        _ = stack.record("Home", id: "home")
+        _ = stack.record("Detail", id: "item-1")
+        _ = stack.record("More", id: "more")
+        // Pop back to `home` with an updated display name.
+        #expect(stack.record("Home Updated", id: "home") == "More")
+        #expect(stack.current == "Home Updated")
+        #expect(stack.currentId == "home")
+        #expect(stack.snapshot == ["Home Updated"])
+    }
+
     @Test("Reset clears history")
     func reset() {
         let stack = ScreenStack()

--- a/Tests/ObservabilityTests/UIInteractions/ScreenStackTests.swift
+++ b/Tests/ObservabilityTests/UIInteractions/ScreenStackTests.swift
@@ -77,4 +77,38 @@ struct ScreenStackTests {
         #expect(stack.current == nil)
         #expect(stack.record("Profile") == nil)
     }
+
+    @Test("currentId reflects the most recent screen id")
+    func currentIdTracksTop() {
+        let stack = ScreenStack()
+        _ = stack.record("Home", id: "home")
+        #expect(stack.currentId == "home")
+        _ = stack.record("Detail", id: "item-1")
+        #expect(stack.currentId == "item-1")
+    }
+
+    @Test("currentId is nil when the current screen has no id")
+    func currentIdNilWithoutId() {
+        let stack = ScreenStack()
+        _ = stack.record("Home")
+        #expect(stack.currentId == nil)
+    }
+
+    @Test("currentId follows pop-back to the earlier screen's id")
+    func currentIdAfterPopBack() {
+        let stack = ScreenStack()
+        _ = stack.record("Home", id: "home")
+        _ = stack.record("Detail", id: "item-1")
+        _ = stack.record("More", id: "more")
+        _ = stack.record("Home", id: "home")
+        #expect(stack.currentId == "home")
+    }
+
+    @Test("currentId is nil after reset")
+    func currentIdNilAfterReset() {
+        let stack = ScreenStack()
+        _ = stack.record("Home", id: "home")
+        stack.reset()
+        #expect(stack.currentId == nil)
+    }
 }

--- a/Tests/SessionReplayTests/RRWebEventGeneratorTests.swift
+++ b/Tests/SessionReplayTests/RRWebEventGeneratorTests.swift
@@ -218,6 +218,63 @@ struct RRWebEventGeneratorTests {
         #expect(payload?["pressType"] == nil)
     }
 
+    @Test("Click custom event carries screen_id and screen_name from the interaction")
+    func appendsClickEventWithScreenIdAndName() async throws {
+        let generator = RRWebEventGenerator(
+            log: OSLog(subsystem: "test", category: "test"),
+            title: "Test",
+            method: .overlayTiles()
+        )
+        let interaction = TouchInteraction(
+            id: 1,
+            kind: .touchUp(CGPoint(x: 10, y: 20)),
+            startTimestamp: 1.0,
+            timestamp: 1.0,
+            target: nil,
+            sessionId: "test-session",
+            screenId: "MyApp.ProfileViewController",
+            screenName: "Profile"
+        )
+        let items: [EventQueueItem] = [EventQueueItem(payload: interaction)]
+        let events = await generator.generateEvents(items: items)
+        // touchEnd IncrementalSnapshot + Click custom event
+        let clickEvent = try #require(events.first { $0.type == .Custom })
+        let encoded = try JSONEncoder().encode(clickEvent)
+        let json = try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        let data = json?["data"] as? [String: Any]
+        #expect(data?["tag"] as? String == "Click")
+        let payload = data?["payload"] as? [String: Any]
+        #expect(payload?["screenId"] as? String == "MyApp.ProfileViewController")
+        #expect(payload?["screenName"] as? String == "Profile")
+    }
+
+    @Test("Click custom event omits screen fields when the interaction has none")
+    func appendsClickEventWithoutScreenInfo() async throws {
+        let generator = RRWebEventGenerator(
+            log: OSLog(subsystem: "test", category: "test"),
+            title: "Test",
+            method: .overlayTiles()
+        )
+        let interaction = TouchInteraction(
+            id: 1,
+            kind: .touchUp(CGPoint(x: 10, y: 20)),
+            startTimestamp: 1.0,
+            timestamp: 1.0,
+            target: nil,
+            sessionId: "test-session"
+        )
+        let items: [EventQueueItem] = [EventQueueItem(payload: interaction)]
+        let events = await generator.generateEvents(items: items)
+        let clickEvent = try #require(events.first { $0.type == .Custom })
+        let encoded = try JSONEncoder().encode(clickEvent)
+        let json = try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        let data = json?["data"] as? [String: Any]
+        #expect(data?["tag"] as? String == "Click")
+        let payload = data?["payload"] as? [String: Any]
+        #expect(payload?["screenId"] == nil)
+        #expect(payload?["screenName"] == nil)
+    }
+
     @Test("Appends Track custom event mirroring the web payload shape")
     func appendsTrackEvent() async throws {
         let generator = RRWebEventGenerator(


### PR DESCRIPTION
## Summary

Enhances click/tap analytics on iOS and makes invasive touch instrumentation honor the `instrumentation` config.

- **`event.id` via `ldId`/`ldClick`**: explicit developer-supplied identifier takes precedence over derived platform ids (`UIView.ldId(_:)` for UIKit, `.ldClick(_:)` for SwiftUI, resolved through a non-consuming `LdClickRegistry`).
- **`event.screen_id` + `event.screen_name`**: stamped on both OTel `click` spans and Session Replay click events; `screen_name` threaded from the `ScreenStack`.
- **Manual `trackClick` API** mirroring the auto-captured click shape.
- **`Instrumentation.enabled` / `.disabled`** convenience accessors.
- **Touch-capture gating**: the `UIWindow.sendEvent` swizzle + hit-testing now install only when `instrumentation.userTaps` is enabled **or** Session Replay is recording (SR self-starts the shared, idempotent manager). With both off, no swizzle/hit-testing is installed.
- Fix `UIWindowSwizzleSource` `isActive` idempotency.

## Test plan

- [ ] `LaunchDarklyObservability` + `LaunchDarklySessionReplay` build (simulator)
- [ ] Unit tests (`LdClickRegistryTests`, `ClickSpanTests`) pass
- [ ] TestApp: taps emit `event.id` (ldId), `event.screen_id`, `event.screen_name` on spans and SR
- [ ] `instrumentation: .disabled` with SR off ⇒ no swizzle/hit-testing

Made with [Cursor](https://cursor.com)