### PR TITLE
fix: report service.name and service.version as resource attributes

### DIFF
--- a/Sources/LaunchDarklyObservability/API/SemanticConvention.swift
+++ b/Sources/LaunchDarklyObservability/API/SemanticConvention.swift
@@ -6,6 +6,8 @@ public enum SemanticConvention {
     public static let telemetrySdkName = "telemetry.sdk.name"
     public static let telemetryDistroName = "telemetry.distro.name"
     public static let telemetryDistroVersion = "telemetry.distro.version"
+    public static let serviceName = "service.name"
+    public static let serviceVersion = "service.version"
     public static let serviceNamespace = "service.namespace"
     public static let systemCpuUtilization = "system.cpu.utilization"
     public static let systemMemoryAppUsageBytes = "system.memory.app_usage_bytes"

--- a/Sources/LaunchDarklyObservability/Plugin/Observability.swift
+++ b/Sources/LaunchDarklyObservability/Plugin/Observability.swift
@@ -94,6 +94,8 @@ extension Observability {
     }
     
     func add(metadata: EnvironmentMetadata, into resourceAttributes: inout [String: AttributeValue]) {
+        resourceAttributes[SemanticConvention.serviceName] = .string(options.serviceName)
+        resourceAttributes[SemanticConvention.serviceVersion] = .string(options.serviceVersion)
         resourceAttributes[SemanticConvention.launchdarklySdkVersion] = .string(String(format: "%@/%@", metadata.sdkMetadata.name, metadata.sdkMetadata.version))
         resourceAttributes[SemanticConvention.highlightProjectId] = .string(metadata.credential)
         resourceAttributes[SemanticConvention.telemetrySdkName] = .string("opentelemetry")


### PR DESCRIPTION
## Summary
- `service.name` (and `service.version`) were missing from exported spans/logs/metrics. The value was only applied to the **instrumentation scope**, not the OpenTelemetry **resource**, so backends saw an empty `service.name`.
- This is a regression from #176, which removed the lines that copied `options.serviceName` / `options.serviceVersion` into the resource attributes. They had been present since Oct 2025 (#36).
- Restores those resource attributes in `Observability.add(metadata:into:)` and re-adds the `service.name` / `service.version` constants to `SemanticConvention`.

## Changes
- `SemanticConvention`: re-add `serviceName` (`service.name`) and `serviceVersion` (`service.version`).
- `Observability.add(metadata:into:)`: populate `service.name` / `service.version` resource attributes from `options.serviceName` / `options.serviceVersion`.

## Test plan
- [ ] Build the SDK and TestApp.
- [ ] Emit a span/log/metric and confirm the exported OTLP `resource.attributes` now includes `service.name` (and `service.version`).
- [ ] Confirm the value reflects `ObservabilityOptions.serviceName` (e.g. `observability-ios-test-app` in the TestApp).

Made with [Cursor](https://cursor.com)