### PR TITLE
fix: skip CameraUI layer subtrees to prevent fatal crash on iOS 26+

### DIFF
--- a/Sources/LaunchDarklySessionReplay/ScreenCapture/MaskCollector.swift
+++ b/Sources/LaunchDarklySessionReplay/ScreenCapture/MaskCollector.swift
@@ -184,6 +184,12 @@ final class MaskCollector {
             } else {
                 if markerOverrideForLayer?.ignore == true { return }
 
+                // Guard against private CameraUI layer subclasses (e.g. CameraUI.ModeLoupeLayer
+                // on iOS 26+) that have no backing UIView and do not implement init(layer:).
+                // Without this guard, accessing .sublayers below triggers CA::Layer::presentation_layer()
+                // which calls the missing initializer and produces a fatal EXC_BREAKPOINT crash.
+                if NSStringFromClass(type(of: layer)).hasPrefix("CameraUI") { return }
+
                 let resolvedExplicitMask: Bool?
                 if inheritedExplicitMask == true || markerOverrideForLayer?.mask == true {
                     resolvedExplicitMask = true

--- a/Sources/LaunchDarklySessionReplay/ScreenCapture/MaskCollector.swift
+++ b/Sources/LaunchDarklySessionReplay/ScreenCapture/MaskCollector.swift
@@ -143,6 +143,14 @@ final class MaskCollector {
         }
 
         func visit(layer: CALayer, inheritedExplicitMask: Bool?) {
+            // On iOS 26+, CameraUI private CALayer subclasses (e.g. ModeLoupeLayer) do not
+            // implement init(layer:). Guard at the very top — before ANY property access —
+            // because even isHidden/opacity access can trigger CA::Layer::presentation_layer()
+            // on a layer that lacks the initializer. The same guard is applied at every
+            // sublayer iteration site so CameraUI layers are never passed to visit() at all;
+            // this check is belt-and-suspenders for any path not covered there.
+            if NSStringFromClass(type(of: layer)).hasPrefix("CameraUI") { return }
+
             guard !layer.isHidden, layer.opacity >= policy.minimumAlpha else { return }
 
             // Frame in root coords is needed both for marker-area lookup
@@ -184,12 +192,6 @@ final class MaskCollector {
             } else {
                 if markerOverrideForLayer?.ignore == true { return }
 
-                // Guard against private CameraUI layer subclasses (e.g. CameraUI.ModeLoupeLayer
-                // on iOS 26+) that have no backing UIView and do not implement init(layer:).
-                // Without this guard, accessing .sublayers below triggers CA::Layer::presentation_layer()
-                // which calls the missing initializer and produces a fatal EXC_BREAKPOINT crash.
-                if NSStringFromClass(type(of: layer)).hasPrefix("CameraUI") { return }
-
                 let resolvedExplicitMask: Bool?
                 if inheritedExplicitMask == true || markerOverrideForLayer?.mask == true {
                     resolvedExplicitMask = true
@@ -202,23 +204,40 @@ final class MaskCollector {
                 childInheritedMask = resolvedExplicitMask
             }
 
-            // Recurse into sublayers in z-order. Skip the `sorted()`
-            // allocation for the common case of zero or one
-            // sublayers (wrapper views, leaf nodes).
-            guard let sublayers = layer.sublayers, !sublayers.isEmpty else { return }
-            if sublayers.count == 1 {
-                visit(layer: sublayers[0], inheritedExplicitMask: childInheritedMask)
+            // Recurse into sublayers in z-order.
+            //
+            // Use model sublayers and pass them directly to visit() — do NOT call
+            // .presentation() on each sublayer. On iOS 26+, calling .presentation()
+            // on any ancestor of CameraUI.ModeLoupeLayer eagerly builds presentation
+            // copies for the entire descendant tree, which calls init(layer:) on
+            // ModeLoupeLayer and crashes with a fatal EXC_BREAKPOINT. Traversing model
+            // layers avoids this. Mask positions may be slightly off during active
+            // animations, but correctness under normal (non-animating) state is preserved.
+            guard let modelSublayers = layer.model().sublayers, !modelSublayers.isEmpty else { return }
+            let safeSublayers = modelSublayers.filter {
+                !NSStringFromClass(type(of: $0)).hasPrefix("CameraUI")
+            }
+            guard !safeSublayers.isEmpty else { return }
+            if safeSublayers.count == 1 {
+                visit(layer: safeSublayers[0], inheritedExplicitMask: childInheritedMask)
             } else {
-                sublayers.sorted { $0.zPosition < $1.zPosition }
+                safeSublayers.sorted { $0.zPosition < $1.zPosition }
                     .forEach { visit(layer: $0, inheritedExplicitMask: childInheritedMask) }
             }
         }
 
-        if let rootSublayers = rPresentation.sublayers, !rootSublayers.isEmpty {
-            if rootSublayers.count == 1 {
-                visit(layer: rootSublayers[0], inheritedExplicitMask: nil)
+        // Use model sublayers at the root level for the same reason: .sublayers on a
+        // presentation layer creates presentation copies of all children, crashing on
+        // iOS 26 if any child is or contains CameraUI.ModeLoupeLayer.
+        let rootModelSublayers = rPresentation.model().sublayers ?? []
+        let safeRootSublayers = rootModelSublayers.filter {
+            !NSStringFromClass(type(of: $0)).hasPrefix("CameraUI")
+        }
+        if !safeRootSublayers.isEmpty {
+            if safeRootSublayers.count == 1 {
+                visit(layer: safeRootSublayers[0], inheritedExplicitMask: nil)
             } else {
-                rootSublayers.sorted { $0.zPosition < $1.zPosition }
+                safeRootSublayers.sorted { $0.zPosition < $1.zPosition }
                     .forEach { visit(layer: $0, inheritedExplicitMask: nil) }
             }
         }

--- a/Sources/LaunchDarklySessionReplay/ScreenCapture/MaskingPolicy.swift
+++ b/Sources/LaunchDarklySessionReplay/ScreenCapture/MaskingPolicy.swift
@@ -80,6 +80,13 @@ final class MaskingPolicy {
     }
 
     func shouldIgnore(_ view: UIView, viewType: AnyClass) -> Bool {
+        // Skip entire CameraUI subtrees on iOS 26+. CameraUI.ModeLoupeLayer (a private
+        // CALayer subclass in this hierarchy) does not implement init(layer:). Accessing
+        // .sublayers on its parent causes CA::Layer::presentation_layer() to call the
+        // missing initializer, producing a fatal EXC_BREAKPOINT crash. Returning true
+        // here stops recursion into the subtree before we ever reach that layer.
+        if String(describing: viewType).hasPrefix("CameraUI") { return true }
+
         if SessionReplayAssociatedObjects.shouldIgnoreUIView(view) == true {
             return true
         }


### PR DESCRIPTION
## Summary

Fixes a fatal `EXC_BREAKPOINT` crash (`Fatal error: Use of unimplemented initializer 'init(layer:)' for class 'CameraUI.ModeLoupeLayer'`) that occurs on iOS 26 when LaunchDarkly Session Replay is enabled and camera UI is visible on screen.

### Root cause

On iOS 26, `CameraUI.ModeLoupeLayer` is a private `CALayer` subclass that does **not** implement `init(layer:)` — the Core Animation initializer used to create presentation layer copies. The crash is triggered any time CA is asked to build a presentation copy of this layer, which happens in three distinct ways inside `MaskCollector.collectViewMasks`:

1. **`layer.sublayers` on a presentation layer** — accessing `.sublayers` on a presentation layer causes Core Animation to call `CA::Layer::presentation_layer()` on every direct child to produce presentation copies. If any child is `CameraUI.ModeLoupeLayer`, this immediately crashes.

2. **`.presentation()` on an ancestor of `CameraUI.ModeLoupeLayer`** — on iOS 26, calling `.presentation()` on a layer that has `CameraUI.ModeLoupeLayer` anywhere in its **descendant** tree eagerly builds presentation copies for the entire subtree, hitting the same crash.

3. **A `CameraUI.*` layer reaching `visit()` with no guard** — without an early exit, later property accesses inside `visit` can also trigger presentation layer creation on the unsafe layer.

This was verified by iterating three fix attempts, each confirmed to recompile via `LaunchDarklySessionReplay.o` timestamp and tested on a physical device running iOS 26 (Xcode 26.x builds):

| Attempt | Change | Result |
|---|---|---|
| 1 | `CameraUI` guard only in the layer-only `else` branch | Still crashed — `layer.sublayers` on presentation layer with CameraUI child (`symbolLocation:1992`) |
| 2 | `layer.model().sublayers` + filter + `.map { $0.presentation() ?? $0 }` | Still crashed — `.presentation()` on a non-CameraUI ancestor with CameraUI descendant (`symbolLocation:2508`) |
| 3 (this PR) | `layer.model().sublayers` + filter, no `.presentation()` call; CameraUI guard at top of `visit()` | ✅ No crash |

### Changes

**`MaskCollector.swift`**

- Added a `CameraUI.*` class-name guard as the **very first line** of `visit()`, before any property access (belt-and-suspenders for any layer that reaches `visit()` directly).
- Replaced `layer.sublayers` (presentation) with `layer.model().sublayers` at both the root traversal site and inside `visit()` for recursion.
- Removed the `.map { $0.presentation() ?? $0 }` step entirely — model layers are passed directly to `visit()`, so `.presentation()` is never called on any individual sublayer.
- Filters out `CameraUI.*` layers before passing sublayers to `visit()`.

**`MaskingPolicy.swift`**

- Added a `CameraUI.*` prefix check at the top of `shouldIgnore(_:viewType:)` to stop recursion into camera UI subtrees at the UIView level as well.

### Tradeoff

Mask positions are now computed from model-layer coordinates rather than presentation-layer (animated) coordinates. During active CA animations, masks may lag slightly behind animated views. Under normal non-animating state, correctness is fully preserved. This is an acceptable tradeoff versus a fatal crash.

### Testing

Validated on a physical device (iOS 26) with session replay `isEnabled: true`, release build, by navigating to the camera picker flow that shows `CameraUI.ModeLoupeLayer`. All three prior crash sites (`symbolLocation:1992`, `2508`) are no longer triggered.