### PR TITLE
feat(observability): resolve React Native nativeID for click event.id

### DIFF
--- a/Sources/LaunchDarklyObservability/UIInteractions/TargetResolver.swift
+++ b/Sources/LaunchDarklyObservability/UIInteractions/TargetResolver.swift
@@ -59,7 +59,8 @@ final class TargetResolver: TargetResolving {
 
     func resolve(press: UIPress, window: UIWindow) -> TouchTarget? {
         guard let hitView = press.responder as? UIView else { return nil }
-        return touchTarget(for: nearestSemanticView(view: hitView), ldId: ldIdWalkingUp(from: hitView), window: window)
+        let ldId = ldIdWalkingUp(from: hitView) ?? reactNativeIdWalkingUp(from: hitView)
+        return touchTarget(for: nearestSemanticView(view: hitView), ldId: ldId, window: window)
     }
     
     private func touchTarget(for semanticView: UIView, ldId: String?, window: UIWindow) -> TouchTarget {
@@ -87,13 +88,18 @@ final class TargetResolver: TargetResolving {
     /// 1. A `.ldClick(_:)` gesture recorded at this tap (SwiftUI, location-matched against any of
     ///    [candidatePoints], which cover the window/screen coordinate spaces `.global` may use).
     /// 2. `UIView.ldId(_:)` on the hit view or an ancestor (UIKit).
-    /// 3. A locationless `.ldClick(_:)` entry (older SwiftUI versions that report no coordinates),
+    /// 3. React Native's `nativeID` on the hit view or an ancestor (set directly or via the RN SDK's
+    ///    `<LDClick id:>` wrapper). An explicit developer id, so it outranks the locationless fallback.
+    /// 4. A locationless `.ldClick(_:)` entry (older SwiftUI versions that report no coordinates),
     ///    used only as a last resort so it can't mask a real UIKit id or bleed into a later tap.
     private func resolveLdId(hitView: UIView, candidatePoints: [CGPoint]) -> String? {
         if let id = LdClickRegistry.shared.id(atAnyOf: candidatePoints) {
             return id
         }
         if let id = ldIdWalkingUp(from: hitView) {
+            return id
+        }
+        if let id = reactNativeIdWalkingUp(from: hitView) {
             return id
         }
         return LdClickRegistry.shared.locationlessId()
@@ -105,6 +111,40 @@ final class TargetResolver: TargetResolving {
         while let cur = v {
             if let id = LdIdStorage.get(cur), !id.isEmpty { return id }
             v = cur.superview
+        }
+        return nil
+    }
+
+    /// Walks up from [view] returning the nearest ancestor's React Native `nativeID`, or `nil`.
+    ///
+    /// React Native sets the JS `nativeID` prop on the UIView backing a JS element; the LaunchDarkly
+    /// React Native SDK's `<LDClick id:>` wrapper sets it to carry a stable analytics id down to
+    /// native. The two RN architectures expose it under different names — Paper via the
+    /// `UIView (React)` category property `nativeID`, Fabric via `RCTViewComponentView.nativeId` — so
+    /// [reactNativeId] checks both. Read reflectively (KVC after a `responds(to:)` guard) to avoid a
+    /// compile-time dependency on React Native; plain UIKit views simply return `nil`.
+    func reactNativeIdWalkingUp(from view: UIView) -> String? {
+        var v: UIView? = view
+        while let cur = v {
+            if let id = reactNativeId(of: cur) { return id }
+            v = cur.superview
+        }
+        return nil
+    }
+
+    private static let fabricNativeIdSelector = Selector(("nativeId"))
+    private static let paperNativeIDSelector = Selector(("nativeID"))
+
+    /// Returns the view's React Native id (non-empty), checking the Fabric (`nativeId`) then Paper
+    /// (`nativeID`) property. Returns `nil` when the view exposes neither or the value is empty.
+    private func reactNativeId(of view: UIView) -> String? {
+        if view.responds(to: Self.fabricNativeIdSelector),
+           let id = view.value(forKey: "nativeId") as? String, !id.isEmpty {
+            return id
+        }
+        if view.responds(to: Self.paperNativeIDSelector),
+           let id = view.value(forKey: "nativeID") as? String, !id.isEmpty {
+            return id
         }
         return nil
     }

--- a/Tests/ObservabilityTests/UIInteractions/ReactNativeIdResolutionTests.swift
+++ b/Tests/ObservabilityTests/UIInteractions/ReactNativeIdResolutionTests.swift
@@ -1,0 +1,74 @@
+#if canImport(UIKit)
+import UIKit
+import Testing
+@testable import LaunchDarklyObservability
+
+/// Tests for [TargetResolver]'s React Native `nativeID` resolution, which supplies `event.id` for
+/// taps in RN apps (set directly or via the RN SDK's `<LDClick id:>` wrapper).
+@MainActor
+struct ReactNativeIdResolutionTests {
+    /// Stand-in for a Paper (old architecture) React Native view: React-Core adds a `nativeID`
+    /// category property to `UIView`.
+    private final class FakePaperView: UIView {
+        @objc var nativeID: String?
+    }
+
+    /// Stand-in for a Fabric (new architecture) React Native view: `RCTViewComponentView` exposes a
+    /// `nativeId` property.
+    private final class FakeFabricView: UIView {
+        @objc var nativeId: String?
+    }
+
+    private let resolver = TargetResolver()
+
+    @Test("reads a Paper `nativeID` set directly on the hit view")
+    func readsPaperNativeID() {
+        let view = FakePaperView()
+        view.nativeID = "checkout.pay_button"
+        #expect(resolver.reactNativeIdWalkingUp(from: view) == "checkout.pay_button")
+    }
+
+    @Test("reads a Fabric `nativeId` set directly on the hit view")
+    func readsFabricNativeId() {
+        let view = FakeFabricView()
+        view.nativeId = "checkout.pay_button"
+        #expect(resolver.reactNativeIdWalkingUp(from: view) == "checkout.pay_button")
+    }
+
+    @Test("walks up to the nearest ancestor carrying a nativeID")
+    func walksUpToAncestor() {
+        let wrapper = FakePaperView()
+        wrapper.nativeID = "card.root"
+        let child = UIView()
+        wrapper.addSubview(child)
+        #expect(resolver.reactNativeIdWalkingUp(from: child) == "card.root")
+    }
+
+    @Test("prefers the closest ancestor")
+    func prefersClosestAncestor() {
+        let outer = FakePaperView()
+        outer.nativeID = "card.root"
+        let inner = FakePaperView()
+        inner.nativeID = "card.cta"
+        outer.addSubview(inner)
+        let child = UIView()
+        inner.addSubview(child)
+        #expect(resolver.reactNativeIdWalkingUp(from: child) == "card.cta")
+    }
+
+    @Test("returns nil when no view in the chain exposes a nativeID")
+    func returnsNilForPlainViews() {
+        let parent = UIView()
+        let child = UIView()
+        parent.addSubview(child)
+        #expect(resolver.reactNativeIdWalkingUp(from: child) == nil)
+    }
+
+    @Test("ignores an empty nativeID")
+    func ignoresEmptyNativeID() {
+        let view = FakePaperView()
+        view.nativeID = ""
+        #expect(resolver.reactNativeIdWalkingUp(from: view) == nil)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

React Native taps are captured natively, but there was no way for an RN developer to attach a stable, chosen analytics id to an element — the only lever reaching native was `testID`, which is overloaded with e2e testing and stripped by session-replay privacy masking.

This teaches `TargetResolver` to read a view's React Native `nativeID` (walking up the hierarchy) and fold it into the existing `ldId` slot, so it becomes `event.id` on `click` spans and replay click events, ahead of `accessibilityIdentifier`. The RRWeb click payload already reads `target.ldId`, so it benefits with no change.

- Covers both RN architectures: Paper's `UIView (React).nativeID` and Fabric's `RCTViewComponentView.nativeId`.
- Read reflectively (`responds(to:)` + KVC) so there is **no compile-time dependency on React Native**; plain UIKit views return `nil`.
- Backs the RN SDK's new `<LDClick id>` wrapper (which sets `nativeID`) on iOS. Companion PR: launchdarkly/observability-sdk#683.

### `event.id` resolution priority (after this change)

`.ldClick` registry (SwiftUI) > `UIView.ldId` (UIKit) > **RN `nativeID`** > locationless `.ldClick` fallback; then `accessibilityIdentifier` as the fallback in span/RRWeb building.

## Test plan

- [x] New `ReactNativeIdResolutionTests` (Paper `nativeID`, Fabric `nativeId`, walk-up, closest-ancestor, plain-view -> nil, empty -> nil)
- [x] Existing `ClickSpanTests` / `LdIdStorageTests` still pass (16/16 via `./test.sh`)
- [ ] After merge + release, bump the pod version consumed by `@launchdarkly/session-replay-react-native` and verify end-to-end on an iOS device

Made with [Cursor](https://cursor.com)