### PR TITLE
fix: de-flake FlushableWorker tests and scale timer leeway to interval

### DIFF
--- a/Sources/LaunchDarklyObservability/Transport/FlushableWorker.swift
+++ b/Sources/LaunchDarklyObservability/Transport/FlushableWorker.swift
@@ -51,8 +51,11 @@ actor FlushableWorker {
         // enqueued even when that pool is briefly saturated (e.g. on a busy CI
         // machine). This is what made the interval test flaky.
         let timer = DispatchSource.makeTimerSource(queue: DispatchQueue.global(qos: .utility))
-        // leeway is big for performance, non need super precision in production (if tests flakey decrease just for test)
-        timer.schedule(deadline: .now() + interval, repeating: interval, leeway: .milliseconds(300))
+        // Leeway is coarse on purpose - the flush cadence doesn't need precision and loose timers
+        // coalesce wake-ups - but it scales with the interval and is capped at 300ms, so a short
+        // interval never gets a leeway larger than the interval it is supposed to honour.
+        let leeway = min(interval / 10, 0.3)
+        timer.schedule(deadline: .now() + interval, repeating: interval, leeway: .milliseconds(Int(leeway * 1000)))
         timer.setEventHandler { [weak self] in
             guard let self else { return }
             Task { await self.enqueueTick() }

--- a/Tests/ObservabilityTests/Transport/FlushableWorkerTests.swift
+++ b/Tests/ObservabilityTests/Transport/FlushableWorkerTests.swift
@@ -41,18 +41,25 @@ struct FlushableWorkerTests {
         }
     }
 
-    /// Suspends until `condition` holds, giving up after `polls` attempts.
+    /// Suspends until `condition` holds, failing the test if it never does within `polls` attempts.
     ///
     /// The give-up budget is counted in polls rather than wall-clock time on purpose. A deadline
     /// keeps running while the test is not running, so on a loaded CI machine - where the
     /// cooperative pool can stall for seconds at a time - it can expire without the worker or the
     /// poll ever being scheduled, and the test then reports as missing work that was simply never
     /// given a chance to run. A poll budget only shrinks when the test actually gets scheduled.
-    private func waitUntil(_ condition: () async -> Bool, polls: Int = 400) async throws {
+    ///
+    /// Exhausting the budget is reported here rather than left to the caller, so that a caller
+    /// whose remaining assertions would hold vacuously - an equality between two counts that are
+    /// both zero, say - still fails.
+    private func waitUntil(_ condition: () async -> Bool,
+                           polls: Int = 400,
+                           sourceLocation: SourceLocation = #_sourceLocation) async throws {
         for _ in 0 ..< polls {
             if await condition() { return }
             try await Task.sleep(nanoseconds: 25_000_000)
         }
+        Issue.record("Condition never held within \(polls) polls", sourceLocation: sourceLocation)
     }
 
     /// Time given to work that is expected *not* to happen, so the assertion that it didn't happen
@@ -169,6 +176,7 @@ struct FlushableWorkerTests {
         // After stop, there should be no further events
         try await Task.sleep(nanoseconds: settleTime)
         let ticksAfter = await recorder.tickCount
+        #expect(ticksAtStop >= 1, "Expected the worker to have ticked before stop(), otherwise the comparison below holds vacuously")
         #expect(ticksAfter == ticksAtStop, "No additional events after stop()")
     }
     

--- a/Tests/ObservabilityTests/Transport/FlushableWorkerTests.swift
+++ b/Tests/ObservabilityTests/Transport/FlushableWorkerTests.swift
@@ -40,7 +40,25 @@ struct FlushableWorkerTests {
             pending.forEach { $0.resume() }
         }
     }
-    
+
+    /// Suspends until `condition` holds, giving up after `polls` attempts.
+    ///
+    /// The give-up budget is counted in polls rather than wall-clock time on purpose. A deadline
+    /// keeps running while the test is not running, so on a loaded CI machine - where the
+    /// cooperative pool can stall for seconds at a time - it can expire without the worker or the
+    /// poll ever being scheduled, and the test then reports as missing work that was simply never
+    /// given a chance to run. A poll budget only shrinks when the test actually gets scheduled.
+    private func waitUntil(polls: Int = 400, _ condition: () async -> Bool) async throws {
+        for _ in 0 ..< polls {
+            if await condition() { return }
+            try await Task.sleep(nanoseconds: 25_000_000)
+        }
+    }
+
+    /// Time given to work that is expected *not* to happen, so the assertion that it didn't happen
+    /// is meaningful.
+    private let settleTime: UInt64 = 200_000_000
+
     @Test
     func ticksOccurOnInterval() async throws {
         let recorder = Recorder()
@@ -50,18 +68,12 @@ struct FlushableWorkerTests {
         
         await worker.start()
         
-        // Wait until at least 1 tick is observed, with a generous timeout.
-        // Timeout is intentionally large to tolerate scheduler/thread-pool
-        // contention on busy CI machines, which is what made this test flaky.
-        let deadline = Date().addingTimeInterval(30)
-        while await recorder.tickCount < 1 && Date() < deadline {
-            try await Task.sleep(nanoseconds: 10_000_000) // 10ms poll
-        }
+        try await waitUntil { await recorder.tickCount >= 1 }
         
         await worker.stop()
         
         let ticks = await recorder.tickCount
-        #expect(ticks >= 1, "Expected at least a few tick executions")
+        #expect(ticks >= 1, "Expected at least one tick execution")
         let flushes = await recorder.flushCount
         #expect(flushes == 0, "No flushes expected without explicit flush call")
     }
@@ -74,9 +86,9 @@ struct FlushableWorkerTests {
         }
         
         await worker.start()
-        try await Task.sleep(nanoseconds: NSEC_PER_SEC) // allow processing
         await worker.flush()
-        try await Task.sleep(nanoseconds: NSEC_PER_SEC) // allow processing
+        try await waitUntil { await recorder.flushCount >= 1 }
+        try await Task.sleep(nanoseconds: settleTime) // let an unexpected second flush surface
         await worker.stop()
         
         let flushes = await recorder.flushCount
@@ -101,7 +113,8 @@ struct FlushableWorkerTests {
         await worker.flush()
         await worker.flush() // second flush while first is pending should coalesce
         await gate.open()     // release the first flush now that the second has been issued
-        try await Task.sleep(nanoseconds: NSEC_PER_SEC)
+        try await waitUntil { await recorder.flushCount >= 1 }
+        try await Task.sleep(nanoseconds: settleTime) // let a non-coalesced second flush surface
         await worker.stop()
         
         let flushes = await recorder.flushCount
@@ -118,14 +131,22 @@ struct FlushableWorkerTests {
             await recorder.add(isFlushing)
         }
         
+        let began = Date()
         await worker.start()
-        try await Task.sleep(nanoseconds: NSEC_PER_SEC) // allow processing
+        try await Task.sleep(nanoseconds: NSEC_PER_SEC / 2)
         await worker.start() // should be a no-op due to guard
-        try await Task.sleep(nanoseconds: NSEC_PER_SEC) // ~0.21s
+        try await Task.sleep(nanoseconds: NSEC_PER_SEC / 2)
         await worker.stop()
+        let observed = Date().timeIntervalSince(began)
         
+        // One ticking loop can emit at most one tick per interval over the observed window, so a
+        // second loop would roughly double the count. The bound is derived from the measured
+        // window rather than hard-coded because sleeps overshoot on a loaded machine, and a
+        // hard-coded bound turns that overshoot into a spurious failure.
+        let singleLoopTicks = Int(observed / interval) + 2
         let ticks = await recorder.tickCount
-        #expect(ticks <= 50, "Idempotent start should not create multiple ticking loops")
+        #expect(ticks <= singleLoopTicks,
+                "Idempotent start should not create multiple ticking loops (\(ticks) ticks in \(observed)s)")
     }
     
     @Test
@@ -136,12 +157,17 @@ struct FlushableWorkerTests {
         }
         
         await worker.start()
-        try await Task.sleep(nanoseconds: 120_000_000)
+        try await waitUntil { await recorder.tickCount >= 1 }
         await worker.stop()
+        
+        // Sample the baseline only after work that was already in flight when stop() landed has
+        // had a chance to record: cancelling the processing task does not interrupt a unit of work
+        // that has already started, and counting such a tick as post-stop would be a false alarm.
+        try await Task.sleep(nanoseconds: settleTime)
         let ticksAtStop = await recorder.tickCount
         
         // After stop, there should be no further events
-        try await Task.sleep(nanoseconds: 150_000_000)
+        try await Task.sleep(nanoseconds: settleTime)
         let ticksAfter = await recorder.tickCount
         #expect(ticksAfter == ticksAtStop, "No additional events after stop()")
     }
@@ -155,7 +181,8 @@ struct FlushableWorkerTests {
         
         await worker.start()
         await worker.flush() // immediate flush should not be dropped
-        try await Task.sleep(nanoseconds: 200_000_000) // allow processing
+        try await waitUntil { await recorder.flushCount >= 1 }
+        try await Task.sleep(nanoseconds: settleTime) // let a duplicate flush surface
         await worker.stop()
         
         let flushes = await recorder.flushCount

--- a/Tests/ObservabilityTests/Transport/FlushableWorkerTests.swift
+++ b/Tests/ObservabilityTests/Transport/FlushableWorkerTests.swift
@@ -48,7 +48,7 @@ struct FlushableWorkerTests {
     /// cooperative pool can stall for seconds at a time - it can expire without the worker or the
     /// poll ever being scheduled, and the test then reports as missing work that was simply never
     /// given a chance to run. A poll budget only shrinks when the test actually gets scheduled.
-    private func waitUntil(polls: Int = 400, _ condition: () async -> Bool) async throws {
+    private func waitUntil(_ condition: () async -> Bool, polls: Int = 400) async throws {
         for _ in 0 ..< polls {
             if await condition() { return }
             try await Task.sleep(nanoseconds: 25_000_000)


### PR DESCRIPTION
## Summary

CI hit `FlushableWorkerTests.ticksOccurOnInterval()` as a flaky failure. The test waited for the first tick against a 30s **wall-clock** deadline, and a wall-clock deadline keeps running while the test itself is not running. When the cooperative pool stalls under CI load, that deadline can expire without the worker's tick or the test's own poll ever being scheduled — the test then reports a missing tick for a worker that was never given a chance to run.

- **Budget waiting in poll iterations, not wall-clock time** (`waitUntil`). The budget only shrinks when the test actually gets scheduled, so a stalled scheduler cannot burn it.
- **Replace the fixed sleeps in the sibling tests** with the same helper. They had the mirror image of the problem: a fixed `Task.sleep` can elapse before the work it was meant to allow for has run. Assertions about work that should *not* happen keep a short, explicit settle window.
- **`startIsIdempotentDoesNotDoubleTickRate` derives its bound from the measured window** instead of hard-coding `ticks <= 50`. Sleeps overshoot on a loaded machine, and the extra ticks that produces are legitimate — a fixed bound turns them into a spurious failure.
- **`stopCancelsFurtherEmissions` lets in-flight work finish before sampling its baseline.** Cancelling the processing task does not interrupt a unit of work that has already started, so a tick landing just after `stop()` was counted as a post-stop emission.
- **Timer leeway now scales with the interval** (`min(interval / 10, 0.3)`), replacing a flat 300ms that was 12x the interval used by the interval test. The 300ms cap is unchanged for long intervals; at the production interval of 1.5s the leeway goes from 300ms to 150ms.

The suite also drops from ~2.0s to ~1.0s now that it no longer sleeps through fixed delays.

## Test plan

- [x] `FlushableWorkerTests` — 40 consecutive iterations (240 tests) under saturating CPU load, all passing
- [x] Full `ObservabilityTests` target (219 tests)
- [x] Whole package scheme on iOS Simulator — 302 tests across `CommonTests`, `ObservabilityTests`, `SessionReplayTests`

Made with [Cursor](https://cursor.com)
