### PR TITLE
feat(session-replay): stop recording on unrecoverable initialization errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,9 @@ case .started, .alreadyStarted:
     // Session Replay is running.
 case .sampledOut:
     // Session Replay is enabled, but this session was not selected by sampleRate.
+case .unrecoverableError:
+    // The backend refused this launch (for example Session Replay is not available for this
+    // project or region). Recording is attempted again on the next launch.
 case .unavailable:
     // Session Replay has not been registered.
 }

--- a/Sources/Common/GraphQL/GraphQLClient.swift
+++ b/Sources/Common/GraphQL/GraphQLClient.swift
@@ -134,7 +134,33 @@ public enum GraphQLClientError: Error, CustomStringConvertible {
 }
 
 public struct GraphQLError: Decodable {
+    public struct Extensions: Decodable {
+        /// Machine-readable error identifier, e.g. `SESSION_REPLAY_BLOCKED_IN_REGION`.
+        public let code: String?
+        /// The server's own verdict on whether retrying the operation can succeed. Takes precedence
+        /// over any status-code based classification when present.
+        public let retryable: Bool?
+
+        public init(code: String? = nil, retryable: Bool? = nil) {
+            self.code = code
+            self.retryable = retryable
+        }
+    }
+
     public let message: String
+    public let extensions: Extensions?
+
+    public init(message: String, extensions: Extensions? = nil) {
+        self.message = message
+        self.extensions = extensions
+    }
+}
+
+/// Errors-only view of the GraphQL envelope. The public graph also returns this shape alongside a
+/// non-2xx status, where the generic decode has already failed, so error metadata can still be read
+/// from the raw body.
+public struct GraphQLErrorEnvelope: Decodable {
+    public let errors: [GraphQLError]?
 }
 
 public struct GraphQLEmptyData: Decodable {}

--- a/Sources/Common/Network/ErrorRecoverability.swift
+++ b/Sources/Common/Network/ErrorRecoverability.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+/// Classifies request failures as recoverable (retrying may succeed) or unrecoverable (permanent for
+/// this launch). Lives outside Session Replay so every caller of the public graph can share one
+/// verdict instead of re-deriving it from status codes.
+public enum ErrorRecoverability {
+    /// Tests whether an HTTP error status represents a condition that might resolve on its own if we
+    /// retry.
+    /// - Parameter statusCode: the HTTP status
+    /// - Returns: `true` if retrying makes sense; `false` if it should be considered a permanent failure
+    public static func isHttpErrorRecoverable(_ statusCode: Int) -> Bool {
+        guard (400..<500).contains(statusCode) else {
+            return true
+        }
+
+        switch statusCode {
+        case 400, // bad request
+             408, // request timeout
+             429: // too many requests
+            return true
+        default:
+            return false // all other 4xx errors are unrecoverable
+        }
+    }
+
+    /// Classifies any error thrown by ``HttpService`` or ``GraphQLClient``. Errors of unknown origin
+    /// are treated as recoverable: retrying costs a backed-off request, while a wrong permanent
+    /// verdict silently disables a feature for the rest of the launch.
+    public static func isErrorRecoverable(_ error: Error) -> Bool {
+        switch error {
+        case let error as NetworkError:
+            return isRecoverable(error)
+        case let error as GraphQLClientError:
+            return isRecoverable(error)
+        default:
+            return true
+        }
+    }
+
+    private static func isRecoverable(_ error: NetworkError) -> Bool {
+        switch error {
+        case .httpStatus(let statusCode, let data):
+            // A rejected request can still carry a GraphQL envelope, and an explicit `retryable`
+            // there is more specific than the status code, so it wins.
+            if let data, let retryable = retryableFlag(inResponseBody: data) {
+                return retryable
+            }
+            return isHttpErrorRecoverable(statusCode)
+        case .transport, .invalidResponse, .invalidRequest:
+            // Timeouts, connectivity loss and malformed responses carry no permanent signal.
+            return true
+        }
+    }
+
+    private static func isRecoverable(_ error: GraphQLClientError) -> Bool {
+        switch error {
+        case .graphQLErrors(let errors):
+            // The public graph reports rejections as `200` + `errors`, so these are classified like
+            // a generic 4xx: unrecoverable unless the server marks an error retryable.
+            return retryableFlag(in: errors) ?? false
+        case .missingData, .decoding, .queryFileNotFound, .unreadableQueryFile:
+            return true
+        }
+    }
+
+    /// The server's retry verdict for a set of GraphQL errors, or `nil` when none of them states one.
+    private static func retryableFlag(in errors: [GraphQLError]) -> Bool? {
+        if errors.contains(where: { $0.extensions?.retryable == false }) {
+            return false
+        }
+        if errors.contains(where: { $0.extensions?.retryable == true }) {
+            return true
+        }
+        return nil
+    }
+
+    private static func retryableFlag(inResponseBody data: Data) -> Bool? {
+        guard let envelope = try? JSONDecoder().decode(GraphQLErrorEnvelope.self, from: data),
+              let errors = envelope.errors else {
+            return nil
+        }
+        return retryableFlag(in: errors)
+    }
+}

--- a/Sources/Common/Network/GraphQLFaultInjection.swift
+++ b/Sources/Common/Network/GraphQLFaultInjection.swift
@@ -1,0 +1,70 @@
+import Foundation
+import OSLog
+
+#if DEBUG
+/// Debug-only helper for exercising Session Replay's recoverable and unrecoverable error paths on a
+/// device without a backend change. It fails `initializeSession` and `pushPayload` during even clock
+/// minutes and lets them through during odd ones, so a single run alternates between the two states
+/// every minute.
+///
+/// Nothing calls this: it is deliberately left unwired. To use it, add the call at the top of
+/// ``GraphQLClient/execute(query:variables:operationName:headers:)`` and remove it again afterwards:
+///
+/// ```swift
+/// #if DEBUG
+/// try GraphQLFaultInjection.failIfNeeded(operationName: operationName)
+/// #endif
+/// ```
+enum GraphQLFaultInjection {
+    /// The failure to simulate. Change this to exercise a different branch of ``ErrorRecoverability``.
+    enum Mode {
+        /// A GraphQL error carrying `retryable: false`: unrecoverable, so Session Replay stops taking
+        /// screenshots immediately and the refusal is cached for the next launch.
+        case nonRetryableGraphQLError
+        /// `403`: unrecoverable by status code.
+        case unauthorized
+        /// `429`: recoverable, so events stay buffered and the call is retried.
+        case tooManyRequests
+    }
+
+    static let mode = Mode.nonRetryableGraphQLError
+
+    /// Operations covered by the new error handling.
+    static let operationNames: Set<String> = ["initializeSession", "PushPayload"]
+
+    private static let log = OSLog(subsystem: "com.launchdarkly.observability", category: "GraphQLFaultInjection")
+
+    static func failIfNeeded(operationName: String?) throws {
+        guard let operationName,
+              operationNames.contains(operationName),
+              isFailingMinute() else {
+            return
+        }
+
+        os_log("Injecting a simulated %{public}@ failure for %{public}@",
+               log: log,
+               type: .error,
+               String(describing: mode),
+               operationName)
+        throw simulatedError()
+    }
+
+    private static func isFailingMinute(now: Date = Date()) -> Bool {
+        Calendar.current.component(.minute, from: now).isMultiple(of: 2)
+    }
+
+    private static func simulatedError() -> Error {
+        switch mode {
+        case .nonRetryableGraphQLError:
+            return GraphQLClientError.graphQLErrors([
+                GraphQLError(message: "Session replay is not available in this region.",
+                             extensions: .init(code: "SESSION_REPLAY_BLOCKED_IN_REGION", retryable: false))
+            ])
+        case .unauthorized:
+            return NetworkError.httpStatus(403, data: nil)
+        case .tooManyRequests:
+            return NetworkError.httpStatus(429, data: nil)
+        }
+    }
+}
+#endif

--- a/Sources/LaunchDarklySessionReplay/API/SessionReplayStartResult.swift
+++ b/Sources/LaunchDarklySessionReplay/API/SessionReplayStartResult.swift
@@ -7,12 +7,15 @@ public enum SessionReplayStartResult: Equatable {
     case alreadyStarted
     /// Session Replay stayed stopped because the session was sampled out.
     case sampledOut
+    /// Session Replay stayed stopped because the backend refused this launch in a way retrying cannot
+    /// fix. Recording is only attempted again on the next launch, so starting again has no effect.
+    case unrecoverableError
 
     public var isRunning: Bool {
         switch self {
         case .started, .alreadyStarted:
             return true
-        case .unavailable, .sampledOut:
+        case .unavailable, .sampledOut, .unrecoverableError:
             return false
         }
     }

--- a/Sources/LaunchDarklySessionReplay/Exporter/SessionReplayExporter.swift
+++ b/Sources/LaunchDarklySessionReplay/Exporter/SessionReplayExporter.swift
@@ -134,6 +134,7 @@ actor SessionReplayExporter: EventExporting {
             let session = try await initializeSession(sessionSecureId: sessionInfo.id)
             // Accepting the session is the recording verdict on its own: releasing it here rather than
             // after `identifySession` keeps a transient identify failure from withholding screenshots.
+            // An unrecoverable identify failure still refuses the launch, through the catch below.
             report(.allowed)
 
             var identifyPayload = self.identifyPayload

--- a/Sources/LaunchDarklySessionReplay/Exporter/SessionReplayExporter.swift
+++ b/Sources/LaunchDarklySessionReplay/Exporter/SessionReplayExporter.swift
@@ -127,7 +127,9 @@ actor SessionReplayExporter: EventExporting {
     /// and identifies the session.
     private func performInitialization() async throws {
         do {
-            guard let sessionInfo else {
+            // Re-checked because starting this task is itself a suspension point, so a refusal can
+            // arrive between the caller's check and this body.
+            guard !hasFailedUnrecoverably, let sessionInfo else {
                 return
             }
             
@@ -232,6 +234,10 @@ actor SessionReplayExporter: EventExporting {
     
     private func pushPayload(initializedSession: InitializeSessionResponse, events: [Event]) async throws {
         guard events.isNotEmpty else { return }
+        // Every `await` in `export` releases the actor, so a refusal can land between generating a
+        // payload and pushing it — from the startup probe, or from an identify. A refused session
+        // accepts no payloads, and the batch is dropped rather than retried, like any after a refusal.
+        guard !hasFailedUnrecoverably else { return }
         
         let input = PushPayloadVariables(sessionSecureId: initializedSession.secureId, payloadId: "\(nextPayloadId)", events: events)
 
@@ -253,6 +259,8 @@ actor SessionReplayExporter: EventExporting {
     }
     
     private func identifySession(sessionSecureId: String, userObject: [String: String]) async throws {
+        guard !hasFailedUnrecoverably else { return }
+
         try await replayApiService.identifySession(
             sessionSecureId: sessionSecureId,
             userIdentifier: userObject["key"] ?? "unknown",

--- a/Sources/LaunchDarklySessionReplay/Exporter/SessionReplayExporter.swift
+++ b/Sources/LaunchDarklySessionReplay/Exporter/SessionReplayExporter.swift
@@ -267,12 +267,6 @@ actor SessionReplayExporter: EventExporting {
             userObject: userObject)
     }
 
-    /// Keeps the latest identify without contacting the backend, for the initialization a later `start()`
-    /// performs. Used while Session Replay is not recording.
-    func cacheIdentify(identifyPayload: IdentifyItemPayload) {
-        self.identifyPayload = identifyPayload
-    }
-
     func identifySession(identifyPayload: IdentifyItemPayload) async throws {
         // The identify hook stays registered after recording ends, and `initializedSession` outlives the
         // refusal, so without this the abandoned session would keep receiving identify calls.

--- a/Sources/LaunchDarklySessionReplay/Exporter/SessionReplayExporter.swift
+++ b/Sources/LaunchDarklySessionReplay/Exporter/SessionReplayExporter.swift
@@ -267,10 +267,17 @@ actor SessionReplayExporter: EventExporting {
         self.identifyPayload = identifyPayload
 
         guard let initializedSession else { return }
-        
-        try await identifySession(
-            sessionSecureId: initializedSession.secureId,
-            userObject: identifyPayload.attributes)
+
+        do {
+            try await identifySession(
+                sessionSecureId: initializedSession.secureId,
+                userObject: identifyPayload.attributes)
+        } catch {
+            // The caller has nothing to retry an identify with and only logs this, but a refusal ends
+            // recording here like it does for any other request.
+            reportIfUnrecoverable(error)
+            throw error
+        }
     }
 
     /// Safely assigns the cold-launch `Foreground` signal into actor-isolated state (mirroring

--- a/Sources/LaunchDarklySessionReplay/Exporter/SessionReplayExporter.swift
+++ b/Sources/LaunchDarklySessionReplay/Exporter/SessionReplayExporter.swift
@@ -12,7 +12,10 @@ actor SessionReplayExporter: EventExporting {
     private let replayApiService: SessionReplayAPIService
     private let context: SessionReplayContext
     private let sessionManager: SessionManaging
-    private var isInitializing = false
+    /// The initialization attempt in flight, if any. Concurrent callers join it instead of carrying on
+    /// without a session: the startup probe and the first export batch do overlap, and an export that
+    /// returns without pushing is treated as a success, which drops its items from the queue.
+    private var initializationTask: Task<Void, Error>?
     private var eventGenerator: RRWebEventGenerator
     private var log: OSLog
     private var initializedSession: InitializeSessionResponse?
@@ -105,13 +108,24 @@ actor SessionReplayExporter: EventExporting {
     private func initializeSessionIfNeeded() async throws {
         guard !hasFailedUnrecoverably else { return }
         guard initializedSession == nil else { return }
-      
-        guard !isInitializing else { return }
-        isInitializing = true
-        defer {
-            isInitializing = false
+
+        if let initializationTask {
+            // Await the attempt already running, so this caller ends up with the same session, or the
+            // same error to retry on.
+            try await initializationTask.value
+            return
         }
-        
+
+        let task = Task { try await performInitialization() }
+        initializationTask = task
+        defer { initializationTask = nil }
+
+        try await task.value
+    }
+
+    /// One initialization attempt: accepts the session with the backend, reports the recording verdict,
+    /// and identifies the session.
+    private func performInitialization() async throws {
         do {
             guard let sessionInfo else {
                 return

--- a/Sources/LaunchDarklySessionReplay/Exporter/SessionReplayExporter.swift
+++ b/Sources/LaunchDarklySessionReplay/Exporter/SessionReplayExporter.swift
@@ -37,6 +37,14 @@ actor SessionReplayExporter: EventExporting {
         return payloadId
     }
     private var identifyPayload: IdentifyItemPayload?
+    /// Set once the backend rejects the session unrecoverably. Recording cannot come back within this
+    /// process — a new attempt is made only on a fresh launch — so no further requests are made and
+    /// queued items are drained instead of retried.
+    private var hasFailedUnrecoverably = false
+    private var initializationHandler: (@Sendable @MainActor (SessionReplayInitializationVerdict) -> Void)?
+    /// A verdict reached before the handler was attached. The handler is installed from an unordered
+    /// task, so the first verdict is held here rather than dropped.
+    private var pendingVerdict: SessionReplayInitializationVerdict?
     
     init(context: SessionReplayContext,
          replayApiService: SessionReplayAPIService,
@@ -76,8 +84,26 @@ actor SessionReplayExporter: EventExporting {
         self.eventGenerator = RRWebEventGenerator(log: log, title: title, method: context.compression)
         self.initializedSession = nil
     }
+
+    /// Receives every recording verdict. Attached after construction because the observer owns this
+    /// exporter; any verdict reached in the meantime is replayed immediately.
+    func setInitializationHandler(_ handler: @escaping @Sendable @MainActor (SessionReplayInitializationVerdict) -> Void) {
+        initializationHandler = handler
+        if let pendingVerdict {
+            self.pendingVerdict = nil
+            Task { @MainActor in handler(pendingVerdict) }
+        }
+    }
+
+    /// Initializes the session without waiting for the first export batch, so an unrecoverable
+    /// rejection can stop capture at the very start of the launch. Errors are reported through the
+    /// verdict handler, so they are not rethrown here.
+    func prepareSession() async {
+        try? await initializeSessionIfNeeded()
+    }
     
     private func initializeSessionIfNeeded() async throws {
+        guard !hasFailedUnrecoverably else { return }
         guard initializedSession == nil else { return }
       
         guard !isInitializing else { return }
@@ -92,6 +118,10 @@ actor SessionReplayExporter: EventExporting {
             }
             
             let session = try await initializeSession(sessionSecureId: sessionInfo.id)
+            // Accepting the session is the recording verdict on its own: releasing it here rather than
+            // after `identifySession` keeps a transient identify failure from withholding screenshots.
+            report(.allowed)
+
             var identifyPayload = self.identifyPayload
             if identifyPayload == nil {
                 identifyPayload = await IdentifyItemPayload(options: context.observabilityContext.options, sessionAttributes: context.observabilityContext.sessionAttributes, timestamp: Date().timeIntervalSince1970, sessionId: sessionInfo.id)
@@ -103,11 +133,35 @@ actor SessionReplayExporter: EventExporting {
         } catch {
             initializedSession = nil
             os_log("%{public}@", log: log, type: .error, "Failed to initialize Session Replay:\n\(error)")
+            reportIfUnrecoverable(error)
             throw error
         }
     }
+
+    /// Classifies a failed request: recoverable errors are left to the export retry loop (items stay
+    /// buffered until the queue overflows), while an unrecoverable one ends recording for this launch.
+    private func reportIfUnrecoverable(_ error: Error) {
+        guard !ErrorRecoverability.isErrorRecoverable(error) else { return }
+
+        hasFailedUnrecoverably = true
+        let reason = String(describing: error)
+        os_log("%{public}@", log: log, type: .error, "Session Replay stopped, unrecoverable error:\n\(reason)")
+        report(.unrecoverable(reason: reason))
+    }
+
+    private func report(_ verdict: SessionReplayInitializationVerdict) {
+        guard let initializationHandler else {
+            pendingVerdict = verdict
+            return
+        }
+        Task { @MainActor in initializationHandler(verdict) }
+    }
     
     func export(items: [EventQueueItem]) async throws {
+        // Return without pushing so the queue drains: recording is over for this launch, and holding
+        // the items would only keep the buffer full.
+        guard !hasFailedUnrecoverably else { return }
+
         try await initializeSessionIfNeeded()
         guard let initializedSession else { return }
 
@@ -153,8 +207,13 @@ actor SessionReplayExporter: EventExporting {
         guard events.isNotEmpty else { return }
         
         let input = PushPayloadVariables(sessionSecureId: initializedSession.secureId, payloadId: "\(nextPayloadId)", events: events)
-                
-        try await replayApiService.pushPayload(input)
+
+        do {
+            try await replayApiService.pushPayload(input)
+        } catch {
+            reportIfUnrecoverable(error)
+            throw error
+        }
         
         // flushes generating canvas size into pushedCanvasSize
         await eventGenerator.updatePushedCanvasSize()

--- a/Sources/LaunchDarklySessionReplay/Exporter/SessionReplayExporter.swift
+++ b/Sources/LaunchDarklySessionReplay/Exporter/SessionReplayExporter.swift
@@ -247,6 +247,10 @@ actor SessionReplayExporter: EventExporting {
     }
 
     func identifySession(identifyPayload: IdentifyItemPayload) async throws {
+        // The identify hook stays registered after recording ends, and `initializedSession` outlives the
+        // refusal, so without this the abandoned session would keep receiving identify calls.
+        guard !hasFailedUnrecoverably else { return }
+
         self.identifyPayload = identifyPayload
 
         guard let initializedSession else { return }

--- a/Sources/LaunchDarklySessionReplay/Exporter/SessionReplayExporter.swift
+++ b/Sources/LaunchDarklySessionReplay/Exporter/SessionReplayExporter.swift
@@ -176,6 +176,18 @@ actor SessionReplayExporter: EventExporting {
         // the items would only keep the buffer full.
         guard !hasFailedUnrecoverably else { return }
 
+        do {
+            try await performExport(items: items)
+        } catch {
+            // The refusal that just ended recording is not a retryable export failure: rethrowing it
+            // would have the worker back off (up to a minute) still holding a batch nothing accepts
+            // any more, so the drain above would only start once that backoff expires.
+            guard !hasFailedUnrecoverably else { return }
+            throw error
+        }
+    }
+
+    private func performExport(items: [EventQueueItem]) async throws {
         try await initializeSessionIfNeeded()
         guard let initializedSession else { return }
 

--- a/Sources/LaunchDarklySessionReplay/Exporter/SessionReplayExporter.swift
+++ b/Sources/LaunchDarklySessionReplay/Exporter/SessionReplayExporter.swift
@@ -267,6 +267,12 @@ actor SessionReplayExporter: EventExporting {
             userObject: userObject)
     }
 
+    /// Keeps the latest identify without contacting the backend, for the initialization a later `start()`
+    /// performs. Used while Session Replay is not recording.
+    func cacheIdentify(identifyPayload: IdentifyItemPayload) {
+        self.identifyPayload = identifyPayload
+    }
+
     func identifySession(identifyPayload: IdentifyItemPayload) async throws {
         // The identify hook stays registered after recording ends, and `initializedSession` outlives the
         // refusal, so without this the abandoned session would keep receiving identify calls.

--- a/Sources/LaunchDarklySessionReplay/SessionReplayInitializationStore.swift
+++ b/Sources/LaunchDarklySessionReplay/SessionReplayInitializationStore.swift
@@ -1,0 +1,71 @@
+import CryptoKit
+import Foundation
+
+/// Outcome of an `initializeSession` / `pushPayload` attempt as far as recording is concerned.
+enum SessionReplayInitializationVerdict: Equatable {
+    /// The backend accepted the session, so recording may run.
+    case allowed
+    /// The backend refused in a way retrying cannot fix (an unrecoverable status, or a GraphQL error
+    /// marked non-retryable), so recording must stop for this launch.
+    case unrecoverable(reason: String)
+}
+
+/// The last unrecoverable failure, as persisted between launches.
+struct SessionReplayInitializationFailure: Codable, Equatable {
+    let reason: String
+    let timestamp: TimeInterval
+    /// Fingerprint of the SDK key the failure was produced for. Entitlements differ per environment,
+    /// so a verdict from one must not gate another.
+    let environment: String
+}
+
+/// Disk cache of the last unrecoverable Session Replay initialization failure, so the next launch can
+/// hold off on taking screenshots until the backend has answered again.
+///
+/// Only failures are stored: no record means "record immediately", which keeps the common path free of
+/// a startup read/write.
+struct SessionReplayInitializationStore {
+    static let failureKey = "com.launchdarkly.observability.sessionReplay.lastUnrecoverableFailure"
+    /// The reason is diagnostic only, and an error description can carry a whole response body, so it
+    /// is kept short enough to stay cheap to read at every launch.
+    static let maxReasonLength = 512
+
+    private let defaults: UserDefaults
+    private let environment: String
+
+    init(sdkKey: String, defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        self.environment = Self.fingerprint(of: sdkKey)
+    }
+
+    /// The stored failure, or `nil` when there is none or it belongs to a different environment.
+    func loadFailure() -> SessionReplayInitializationFailure? {
+        guard let data = defaults.data(forKey: Self.failureKey),
+              let failure = try? JSONDecoder().decode(SessionReplayInitializationFailure.self, from: data),
+              failure.environment == environment else {
+            return nil
+        }
+        return failure
+    }
+
+    func store(reason: String, timestamp: TimeInterval = Date().timeIntervalSince1970) {
+        let failure = SessionReplayInitializationFailure(reason: String(reason.prefix(Self.maxReasonLength)),
+                                                        timestamp: timestamp,
+                                                        environment: environment)
+        guard let data = try? JSONEncoder().encode(failure) else { return }
+        defaults.set(data, forKey: Self.failureKey)
+    }
+
+    func clearFailure() {
+        defaults.removeObject(forKey: Self.failureKey)
+    }
+
+    /// Distinguishes environments without writing the SDK key itself to disk. Only equality matters,
+    /// so a truncated digest is enough.
+    private static func fingerprint(of sdkKey: String) -> String {
+        SHA256.hash(data: Data(sdkKey.utf8))
+            .prefix(8)
+            .map { String(format: "%02x", $0) }
+            .joined()
+    }
+}

--- a/Sources/LaunchDarklySessionReplay/SessionReplayInitializationStore.swift
+++ b/Sources/LaunchDarklySessionReplay/SessionReplayInitializationStore.swift
@@ -14,9 +14,6 @@ enum SessionReplayInitializationVerdict: Equatable {
 struct SessionReplayInitializationFailure: Codable, Equatable {
     let reason: String
     let timestamp: TimeInterval
-    /// Fingerprint of the SDK key the failure was produced for. Entitlements differ per environment,
-    /// so a verdict from one must not gate another.
-    let environment: String
 }
 
 /// Disk cache of the last unrecoverable Session Replay initialization failure, so the next launch can
@@ -25,39 +22,40 @@ struct SessionReplayInitializationFailure: Codable, Equatable {
 /// Only failures are stored: no record means "record immediately", which keeps the common path free of
 /// a startup read/write.
 struct SessionReplayInitializationStore {
-    static let failureKey = "com.launchdarkly.observability.sessionReplay.lastUnrecoverableFailure"
+    static let failureKeyPrefix = "com.launchdarkly.observability.sessionReplay.lastUnrecoverableFailure"
     /// The reason is diagnostic only, and an error description can carry a whole response body, so it
     /// is kept short enough to stay cheap to read at every launch.
     static let maxReasonLength = 512
 
     private let defaults: UserDefaults
-    private let environment: String
+    private let failureKey: String
 
     init(sdkKey: String, defaults: UserDefaults = .standard) {
         self.defaults = defaults
-        self.environment = Self.fingerprint(of: sdkKey)
+        self.failureKey = Self.failureKey(for: sdkKey)
     }
 
-    /// The stored failure, or `nil` when there is none or it belongs to a different environment.
+    /// The stored failure for this environment, or `nil` when there is none.
     func loadFailure() -> SessionReplayInitializationFailure? {
-        guard let data = defaults.data(forKey: Self.failureKey),
-              let failure = try? JSONDecoder().decode(SessionReplayInitializationFailure.self, from: data),
-              failure.environment == environment else {
-            return nil
-        }
-        return failure
+        guard let data = defaults.data(forKey: failureKey) else { return nil }
+        return try? JSONDecoder().decode(SessionReplayInitializationFailure.self, from: data)
     }
 
     func store(reason: String, timestamp: TimeInterval = Date().timeIntervalSince1970) {
         let failure = SessionReplayInitializationFailure(reason: String(reason.prefix(Self.maxReasonLength)),
-                                                        timestamp: timestamp,
-                                                        environment: environment)
+                                                        timestamp: timestamp)
         guard let data = try? JSONEncoder().encode(failure) else { return }
-        defaults.set(data, forKey: Self.failureKey)
+        defaults.set(data, forKey: failureKey)
     }
 
     func clearFailure() {
-        defaults.removeObject(forKey: Self.failureKey)
+        defaults.removeObject(forKey: failureKey)
+    }
+
+    /// Entitlements differ per environment, so a verdict from one must neither gate another nor
+    /// overwrite what is cached for it — hence a key per SDK key rather than a shared one.
+    static func failureKey(for sdkKey: String) -> String {
+        "\(failureKeyPrefix).\(fingerprint(of: sdkKey))"
     }
 
     /// Distinguishes environments without writing the SDK key itself to disk. Only equality matters,

--- a/Sources/LaunchDarklySessionReplay/SessionReplayInitializationStore.swift
+++ b/Sources/LaunchDarklySessionReplay/SessionReplayInitializationStore.swift
@@ -1,7 +1,8 @@
 import CryptoKit
 import Foundation
 
-/// Outcome of an `initializeSession` / `pushPayload` attempt as far as recording is concerned.
+/// Outcome of a Session Replay request as far as recording is concerned. Any of them can refuse the
+/// launch, including the `identifySession` that follows a successful `initializeSession`.
 enum SessionReplayInitializationVerdict: Equatable {
     /// The backend accepted the session, so recording may run.
     case allowed

--- a/Sources/LaunchDarklySessionReplay/SessionReplayRecordingGate.swift
+++ b/Sources/LaunchDarklySessionReplay/SessionReplayRecordingGate.swift
@@ -1,0 +1,62 @@
+/// Decides whether Session Replay may take screenshots, from the recording verdicts seen during this
+/// launch and the unrecoverable failure cached from a previous one.
+///
+/// Kept as a value type (like ``SessionReplaySamplingSession``) so the orderings that matter — a refusal
+/// arriving before `start()`, a launch that begins with screenshots withheld, a refusal after a
+/// recovery — are testable without a live service.
+struct SessionReplayRecordingGate {
+    /// What the owning service must do in response to a verdict.
+    enum Outcome: Equatable {
+        /// Nothing to do: the verdict confirms the state the gate is already in.
+        case none
+        /// Screenshots were withheld and may now start. The cached failure is resolved, so it must be
+        /// erased for the next launch to record from the start.
+        case releaseScreenCapture
+        /// Recording must end for this launch, and `reason` must be persisted so the next launch
+        /// withholds screenshots until the backend has answered.
+        case stopRecording(reason: String)
+    }
+
+    /// Whether screenshots are being held back until the backend accepts the session. Starts out set
+    /// when a previous launch was refused.
+    private var isWithheld: Bool
+    private var hasFailedUnrecoverably = false
+
+    init(hasCachedFailure: Bool) {
+        self.isWithheld = hasCachedFailure
+    }
+
+    /// Screenshots are taken from the start unless a previous launch was refused, in which case the
+    /// backend has to accept the session first.
+    var isScreenCaptureAllowed: Bool {
+        !hasFailedUnrecoverably && !isWithheld
+    }
+
+    /// Whether recording can start at all. A refused launch cannot record again: the exporter stops
+    /// talking to the backend until the process is relaunched.
+    var canStartRecording: Bool {
+        !hasFailedUnrecoverably
+    }
+
+    /// Whether a verdict is still owed while screenshots are withheld, which makes a foreground worth
+    /// another attempt.
+    var isAwaitingVerdict: Bool {
+        !hasFailedUnrecoverably && isWithheld
+    }
+
+    mutating func apply(_ verdict: SessionReplayInitializationVerdict) -> Outcome {
+        switch verdict {
+        case .allowed:
+            // A refusal is final for this launch, and an acceptance changes nothing when screenshots
+            // are already being taken.
+            guard !hasFailedUnrecoverably, isWithheld else { return .none }
+            isWithheld = false
+            return .releaseScreenCapture
+        case .unrecoverable(let reason):
+            guard !hasFailedUnrecoverably else { return .none }
+            hasFailedUnrecoverably = true
+            isWithheld = true
+            return .stopRecording(reason: reason)
+        }
+    }
+}

--- a/Sources/LaunchDarklySessionReplay/SessionReplayService.swift
+++ b/Sources/LaunchDarklySessionReplay/SessionReplayService.swift
@@ -99,6 +99,9 @@ final class SessionReplayService: SessionReplayServicing {
     private var lifecycleCancellable: AnyCancellable?
     /// Whether the one-shot cold-launch foreground has been forwarded to the exporter. Main-thread only.
     private var hasHandledInitialForeground = false
+    /// The most recent identify that arrived while recording was off, delivered by the next `start()`.
+    /// Main-thread only.
+    private var pendingIdentify: IdentifyItemPayload?
     /// Gates queuing of lifecycle breadcrumbs to the recording window so a sampled-out session is not
     /// initialized by a stray transition. Toggled in `internalStart`/`internalStop`. Main-thread only.
     private var lifecycleQueueingEnabled = false
@@ -243,9 +246,10 @@ final class SessionReplayService: SessionReplayServicing {
     func scheduleIdentifySession(identifyPayload: IdentifyItemPayload) async {
         // Nothing is being recorded, so the backend is left alone: the identify hook stays registered
         // after `stop()`, and an unrecoverable answer here would refuse a launch the caller has already
-        // turned off. The payload is kept for the initialization a later `start()` performs.
+        // turned off. The payload waits for the next `start()`, which delivers it. Only the most recent
+        // one is kept: an older identity is stale by then.
         guard _isRunning else {
-            await sessionReplayExporter.cacheIdentify(identifyPayload: identifyPayload)
+            pendingIdentify = identifyPayload
             return
         }
 
@@ -336,13 +340,34 @@ final class SessionReplayService: SessionReplayServicing {
         lifecycleQueueingEnabled = true
 
         // Ask the backend up front instead of waiting for the first export batch, so a refusal can
-        // stop (or keep withholding) screenshots at the very start of the launch.
+        // stop (or keep withholding) screenshots at the very start of the launch. An identify held while
+        // recording was off goes first: initialization no-ops for a session that is still accepted, so
+        // nothing else would deliver it, and going first also means a session accepted from here on is
+        // initialized with the current identity rather than identified twice.
+        let pending = takePendingIdentify()
         let exporter = sessionReplayExporter
-        Task { await exporter.prepareSession() }
+        Task { [weak self] in
+            if let pending {
+                await self?.scheduleIdentifySession(identifyPayload: pending)
+            }
+            await exporter.prepareSession()
+        }
 
         // Input events keep flowing into the event queue meanwhile: they buffer there until the queue
         // overflows, and are pushed as soon as the session is accepted.
         captureManager.isEnabled = recordingGate.isScreenCaptureAllowed
+    }
+
+    /// Consumes the identify held while recording was off, restamped with the session being recorded now:
+    /// the session can have rotated in the meantime, and the timeline event has to land on the current one.
+    @MainActor
+    private func takePendingIdentify() -> IdentifyItemPayload? {
+        guard let pending = pendingIdentify else { return nil }
+        pendingIdentify = nil
+
+        return IdentifyItemPayload(attributes: pending.attributes,
+                                   timestamp: pending.timestamp,
+                                   sessionId: observabilityContext.sessionManager.sessionInfo.id)
     }
 
     /// Asks the backend again while screenshots are withheld by a failure cached from a previous launch.

--- a/Sources/LaunchDarklySessionReplay/SessionReplayService.swift
+++ b/Sources/LaunchDarklySessionReplay/SessionReplayService.swift
@@ -57,6 +57,10 @@ final class SessionReplayService: SessionReplayServicing {
     let log: OSLog
     let sampleRate: Double
     var observabilityContext: ObservabilityContext
+    private let initializationStore: SessionReplayInitializationStore
+    /// Decides whether screenshots may be taken, from this launch's verdicts and the failure cached from
+    /// a previous launch. Main-thread only.
+    private var recordingGate: SessionReplayRecordingGate
     
     @MainActor
     private var _isEnabled = false
@@ -74,9 +78,10 @@ final class SessionReplayService: SessionReplayServicing {
         }
         set {
             guard _isEnabled != newValue else { return }
-            _isEnabled = newValue
             if newValue {
-                _ = start(ignoreSampling: false)
+                // `start` owns `_isEnabled`, except when it refuses: a launch the backend has already
+                // rejected cannot record again, so enabling must not report itself as enabled.
+                _isEnabled = start(ignoreSampling: false) != .unrecoverableError
             } else {
                 stop()
             }
@@ -108,6 +113,10 @@ final class SessionReplayService: SessionReplayServicing {
         self.observabilityContext = observabilityContext
         self.log = observabilityContext.options.log
         self.sampleRate = sessonReplayOptions.sampleRate
+        let initializationStore = SessionReplayInitializationStore(sdkKey: observabilityContext.sdkKey)
+        let cachedFailure = initializationStore.loadFailure()
+        self.initializationStore = initializationStore
+        self.recordingGate = SessionReplayRecordingGate(hasCachedFailure: cachedFailure != nil)
         let graphQLClient = GraphQLClient(endpoint: url, defaultHeaders: ["User-Agent": ObservabilitySDKInfo.userAgent()])
         let captureService = imageCaptureService
             ?? ImageCaptureService(options: sessonReplayOptions)
@@ -140,9 +149,20 @@ final class SessionReplayService: SessionReplayServicing {
                                                           appLaunchSignal: observabilityContext.appLaunchSignal)
         self.sessionReplayExporter = sessionReplayExporter
         
+        let initializationHandler: @Sendable @MainActor (SessionReplayInitializationVerdict) -> Void = { [weak self] verdict in
+            self?.handleInitializationVerdict(verdict)
+        }
         Task {
+            await sessionReplayExporter.setInitializationHandler(initializationHandler)
             await transportService.batchWorker.addExporter(sessionReplayExporter)
             transportService.start()
+        }
+
+        if let cachedFailure {
+            os_log("%{public}@",
+                   log: log,
+                   type: .info,
+                   "Session Replay is holding screenshots until initializeSession succeeds, previous launch failed with:\n\(cachedFailure.reason)")
         }
 
         // Subscribe synchronously here (not in `internalStart`, which is enabled via an async task and
@@ -161,6 +181,12 @@ final class SessionReplayService: SessionReplayServicing {
     /// is never queued here. Subsequent transitions are queued as `Foreground`/`Background`
     /// breadcrumbs, but only while recording so a sampled-out session isn't initialized.
     private func handleAppLifecycleSignal(_ signal: AppLifecycleSignal) {
+        if signal.kind == .foreground {
+            Task { @MainActor [weak self] in
+                self?.retryInitializationIfWithheld()
+            }
+        }
+
         if signal.kind == .foreground, !hasHandledInitialForeground {
             hasHandledInitialForeground = true
             let exporter = sessionReplayExporter
@@ -224,6 +250,13 @@ final class SessionReplayService: SessionReplayServicing {
     
     @MainActor
     func start(ignoreSampling: Bool = false) -> SessionReplayStartResult {
+        // The exporter stops talking to the backend after an unrecoverable refusal, so starting would
+        // only subscribe to events that can never be pushed. The next launch tries again.
+        guard recordingGate.canStartRecording else {
+            os_log("LaunchDarkly Session Replay cannot start, the backend refused this launch.", log: log, type: .info)
+            return .unrecoverableError
+        }
+
         _isEnabled = true
         guard !_isRunning else { return .alreadyStarted }
 
@@ -293,7 +326,51 @@ final class SessionReplayService: SessionReplayServicing {
         // wake-up export batch.
         lifecycleQueueingEnabled = true
 
-        captureManager.isEnabled = true
+        // Ask the backend up front instead of waiting for the first export batch, so a refusal can
+        // stop (or keep withholding) screenshots at the very start of the launch.
+        let exporter = sessionReplayExporter
+        Task { await exporter.prepareSession() }
+
+        // Input events keep flowing into the event queue meanwhile: they buffer there until the queue
+        // overflows, and are pushed as soon as the session is accepted.
+        captureManager.isEnabled = recordingGate.isScreenCaptureAllowed
+    }
+
+    /// Asks the backend again while screenshots are withheld by a failure cached from a previous launch.
+    /// A launch that starts in the background often probes with no network, or is suspended mid-request,
+    /// and becoming visible is the moment worth retrying: with capture withheld there are no frames to
+    /// export, so nothing else would trigger an attempt until the user happens to tap or navigate.
+    @MainActor
+    private func retryInitializationIfWithheld() {
+        guard _isRunning, recordingGate.isAwaitingVerdict else { return }
+
+        let exporter = sessionReplayExporter
+        Task { await exporter.prepareSession() }
+    }
+
+    /// Applies a recording verdict from the exporter: an accepted session releases screen capture (and
+    /// clears any cached failure), a refused one ends recording for this launch and is remembered so the
+    /// next launch does not take screenshots before the backend has answered.
+    @MainActor
+    private func handleInitializationVerdict(_ verdict: SessionReplayInitializationVerdict) {
+        switch recordingGate.apply(verdict) {
+        case .none:
+            break
+        case .releaseScreenCapture:
+            initializationStore.clearFailure()
+            os_log("LaunchDarkly Session Replay recovered, resuming screenshots.", log: log, type: .info)
+            if _isRunning {
+                captureManager.isEnabled = true
+            }
+        case .stopRecording(let reason):
+            initializationStore.store(reason: reason)
+            // Recording is over for this launch, so report Session Replay as disabled rather than
+            // leaving `isEnabled` claiming otherwise.
+            _isEnabled = false
+            guard _isRunning else { return }
+            _isRunning = false
+            internalStop()
+        }
     }
     
     @MainActor

--- a/Sources/LaunchDarklySessionReplay/SessionReplayService.swift
+++ b/Sources/LaunchDarklySessionReplay/SessionReplayService.swift
@@ -239,7 +239,16 @@ final class SessionReplayService: SessionReplayServicing {
         }
     }
     
+    @MainActor
     func scheduleIdentifySession(identifyPayload: IdentifyItemPayload) async {
+        // Nothing is being recorded, so the backend is left alone: the identify hook stays registered
+        // after `stop()`, and an unrecoverable answer here would refuse a launch the caller has already
+        // turned off. The payload is kept for the initialization a later `start()` performs.
+        guard _isRunning else {
+            await sessionReplayExporter.cacheIdentify(identifyPayload: identifyPayload)
+            return
+        }
+
         do {
             try await sessionReplayExporter.identifySession(identifyPayload: identifyPayload)
             await transportService.eventQueue.send(identifyPayload)

--- a/Tests/CommonTests/Network/ErrorRecoverabilityTests.swift
+++ b/Tests/CommonTests/Network/ErrorRecoverabilityTests.swift
@@ -1,0 +1,98 @@
+import Foundation
+import Testing
+@testable import Common
+
+private func graphQLErrorBody(retryable: Bool?, code: String = "SESSION_REPLAY_BLOCKED_IN_REGION") -> Data {
+    let extensions = retryable.map { "\"extensions\": { \"code\": \"\(code)\", \"retryable\": \($0) }" } ?? "\"extensions\": { \"code\": \"\(code)\" }"
+    return Data("""
+        {
+          "errors": [
+            {
+              "message": "Session replay is not available in this region.",
+              \(extensions)
+            }
+          ]
+        }
+        """.utf8)
+}
+
+@Suite("ErrorRecoverability")
+struct ErrorRecoverabilityTests {
+
+    @Test("4xx statuses are unrecoverable except 400, 408 and 429")
+    func clientErrorStatuses() {
+        #expect(ErrorRecoverability.isHttpErrorRecoverable(400))
+        #expect(ErrorRecoverability.isHttpErrorRecoverable(408))
+        #expect(ErrorRecoverability.isHttpErrorRecoverable(429))
+
+        for statusCode in [401, 402, 403, 404, 405, 409, 422, 451, 499] {
+            #expect(ErrorRecoverability.isHttpErrorRecoverable(statusCode) == false, "\(statusCode) should be unrecoverable")
+        }
+    }
+
+    @Test("Server errors and success statuses are recoverable")
+    func serverErrorStatuses() {
+        for statusCode in [200, 302, 500, 502, 503, 504] {
+            #expect(ErrorRecoverability.isHttpErrorRecoverable(statusCode), "\(statusCode) should be recoverable")
+        }
+    }
+
+    @Test("Network errors are classified by status code")
+    func networkErrorsUseStatusCode() {
+        #expect(ErrorRecoverability.isErrorRecoverable(NetworkError.httpStatus(403, data: nil)) == false)
+        #expect(ErrorRecoverability.isErrorRecoverable(NetworkError.httpStatus(429, data: nil)))
+        #expect(ErrorRecoverability.isErrorRecoverable(NetworkError.httpStatus(500, data: nil)))
+    }
+
+    @Test("Timeouts and transport failures are recoverable")
+    func transportFailuresAreRecoverable() {
+        #expect(ErrorRecoverability.isErrorRecoverable(NetworkError.transport(URLError(.timedOut))))
+        #expect(ErrorRecoverability.isErrorRecoverable(NetworkError.transport(URLError(.networkConnectionLost))))
+        #expect(ErrorRecoverability.isErrorRecoverable(NetworkError.invalidResponse))
+    }
+
+    @Test("GraphQL response errors are treated as 4xx")
+    func graphQLErrorsAreUnrecoverableByDefault() {
+        let errors = [GraphQLError(message: "Session replay is not available in this region.")]
+        #expect(ErrorRecoverability.isErrorRecoverable(GraphQLClientError.graphQLErrors(errors)) == false)
+    }
+
+    @Test("retryable in GraphQL errors decides the verdict")
+    func graphQLRetryableFlagWins() {
+        let nonRetryable = [GraphQLError(message: "Blocked", extensions: .init(code: "SESSION_REPLAY_BLOCKED_IN_REGION", retryable: false))]
+        #expect(ErrorRecoverability.isErrorRecoverable(GraphQLClientError.graphQLErrors(nonRetryable)) == false)
+
+        let retryable = [GraphQLError(message: "Try later", extensions: .init(code: "BACKEND_BUSY", retryable: true))]
+        #expect(ErrorRecoverability.isErrorRecoverable(GraphQLClientError.graphQLErrors(retryable)))
+
+        let mixed = [
+            GraphQLError(message: "Try later", extensions: .init(retryable: true)),
+            GraphQLError(message: "Blocked", extensions: .init(retryable: false))
+        ]
+        #expect(ErrorRecoverability.isErrorRecoverable(GraphQLClientError.graphQLErrors(mixed)) == false)
+    }
+
+    @Test("retryable in a rejected response body overrides the status code")
+    func retryableInResponseBodyOverridesStatus() {
+        let blocked = NetworkError.httpStatus(403, data: graphQLErrorBody(retryable: true))
+        #expect(ErrorRecoverability.isErrorRecoverable(blocked))
+
+        let throttled = NetworkError.httpStatus(429, data: graphQLErrorBody(retryable: false))
+        #expect(ErrorRecoverability.isErrorRecoverable(throttled) == false)
+
+        let withoutFlag = NetworkError.httpStatus(403, data: graphQLErrorBody(retryable: nil))
+        #expect(ErrorRecoverability.isErrorRecoverable(withoutFlag) == false)
+
+        let unrelatedBody = NetworkError.httpStatus(403, data: Data("not json".utf8))
+        #expect(ErrorRecoverability.isErrorRecoverable(unrelatedBody) == false)
+    }
+
+    @Test("Malformed responses and unknown errors stay recoverable")
+    func unknownErrorsAreRecoverable() {
+        struct SomeError: Error {}
+
+        #expect(ErrorRecoverability.isErrorRecoverable(GraphQLClientError.missingData))
+        #expect(ErrorRecoverability.isErrorRecoverable(GraphQLClientError.decoding(SomeError())))
+        #expect(ErrorRecoverability.isErrorRecoverable(SomeError()))
+    }
+}

--- a/Tests/SessionReplayTests/SessionReplayInitializationStoreTests.swift
+++ b/Tests/SessionReplayTests/SessionReplayInitializationStoreTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Testing
+@testable import LaunchDarklySessionReplay
+
+@Suite("SessionReplayInitializationStore")
+struct SessionReplayInitializationStoreTests {
+
+    private func makeDefaults() -> (UserDefaults, () -> Void) {
+        let suiteName = "com.launchdarkly.observability.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        return (defaults, { UserDefaults().removePersistentDomain(forName: suiteName) })
+    }
+
+    @Test("No failure is stored by default")
+    func noFailureByDefault() {
+        let (defaults, cleanUp) = makeDefaults()
+        defer { cleanUp() }
+
+        let store = SessionReplayInitializationStore(sdkKey: "mob-key", defaults: defaults)
+        #expect(store.loadFailure() == nil)
+    }
+
+    @Test("Stored failure survives a new store for the same environment")
+    func failureRoundTrips() {
+        let (defaults, cleanUp) = makeDefaults()
+        defer { cleanUp() }
+
+        SessionReplayInitializationStore(sdkKey: "mob-key", defaults: defaults)
+            .store(reason: "SESSION_REPLAY_BLOCKED_IN_REGION", timestamp: 42)
+
+        let failure = SessionReplayInitializationStore(sdkKey: "mob-key", defaults: defaults).loadFailure()
+        #expect(failure?.reason == "SESSION_REPLAY_BLOCKED_IN_REGION")
+        #expect(failure?.timestamp == 42)
+    }
+
+    @Test("Failure from another environment is ignored")
+    func failureIsScopedToEnvironment() {
+        let (defaults, cleanUp) = makeDefaults()
+        defer { cleanUp() }
+
+        SessionReplayInitializationStore(sdkKey: "mob-staging", defaults: defaults)
+            .store(reason: "unauthorized")
+
+        #expect(SessionReplayInitializationStore(sdkKey: "mob-production", defaults: defaults).loadFailure() == nil)
+        #expect(SessionReplayInitializationStore(sdkKey: "mob-staging", defaults: defaults).loadFailure() != nil)
+    }
+
+    @Test("Clearing removes the stored failure")
+    func clearingRemovesFailure() {
+        let (defaults, cleanUp) = makeDefaults()
+        defer { cleanUp() }
+
+        let store = SessionReplayInitializationStore(sdkKey: "mob-key", defaults: defaults)
+        store.store(reason: "unauthorized")
+        store.clearFailure()
+
+        #expect(store.loadFailure() == nil)
+    }
+
+    @Test("Long reasons are truncated")
+    func longReasonsAreTruncated() {
+        let (defaults, cleanUp) = makeDefaults()
+        defer { cleanUp() }
+
+        let store = SessionReplayInitializationStore(sdkKey: "mob-key", defaults: defaults)
+        store.store(reason: String(repeating: "x", count: SessionReplayInitializationStore.maxReasonLength * 3))
+
+        #expect(store.loadFailure()?.reason.count == SessionReplayInitializationStore.maxReasonLength)
+    }
+
+    @Test("The SDK key is never written to disk")
+    func sdkKeyIsNotPersisted() throws {
+        let (defaults, cleanUp) = makeDefaults()
+        defer { cleanUp() }
+
+        SessionReplayInitializationStore(sdkKey: "mob-secret-key", defaults: defaults).store(reason: "unauthorized")
+
+        let data = try #require(defaults.data(forKey: SessionReplayInitializationStore.failureKey))
+        let json = try #require(String(data: data, encoding: .utf8))
+        #expect(json.contains("mob-secret-key") == false)
+    }
+}

--- a/Tests/SessionReplayTests/SessionReplayInitializationStoreTests.swift
+++ b/Tests/SessionReplayTests/SessionReplayInitializationStoreTests.swift
@@ -45,6 +45,27 @@ struct SessionReplayInitializationStoreTests {
         #expect(SessionReplayInitializationStore(sdkKey: "mob-staging", defaults: defaults).loadFailure() != nil)
     }
 
+    @Test("One environment's failure does not displace another's")
+    func failuresDoNotOverwriteEachOther() {
+        let (defaults, cleanUp) = makeDefaults()
+        defer { cleanUp() }
+
+        let staging = SessionReplayInitializationStore(sdkKey: "mob-staging", defaults: defaults)
+        let production = SessionReplayInitializationStore(sdkKey: "mob-production", defaults: defaults)
+
+        staging.store(reason: "unauthorized", timestamp: 1)
+        production.store(reason: "blocked in region", timestamp: 2)
+
+        #expect(staging.loadFailure()?.reason == "unauthorized")
+        #expect(production.loadFailure()?.reason == "blocked in region")
+
+        // Clearing is scoped the same way: recovering in one environment leaves the other withheld.
+        production.clearFailure()
+
+        #expect(staging.loadFailure()?.reason == "unauthorized")
+        #expect(production.loadFailure() == nil)
+    }
+
     @Test("Clearing removes the stored failure")
     func clearingRemovesFailure() {
         let (defaults, cleanUp) = makeDefaults()
@@ -75,8 +96,11 @@ struct SessionReplayInitializationStoreTests {
 
         SessionReplayInitializationStore(sdkKey: "mob-secret-key", defaults: defaults).store(reason: "unauthorized")
 
-        let data = try #require(defaults.data(forKey: SessionReplayInitializationStore.failureKey))
+        let key = SessionReplayInitializationStore.failureKey(for: "mob-secret-key")
+        let data = try #require(defaults.data(forKey: key))
         let json = try #require(String(data: data, encoding: .utf8))
         #expect(json.contains("mob-secret-key") == false)
+        // The environment is part of the key name now, so that has to stay a fingerprint too.
+        #expect(key.contains("mob-secret-key") == false)
     }
 }

--- a/Tests/SessionReplayTests/SessionReplayRecordingGateTests.swift
+++ b/Tests/SessionReplayTests/SessionReplayRecordingGateTests.swift
@@ -1,0 +1,68 @@
+import Testing
+@testable import LaunchDarklySessionReplay
+
+@Suite("SessionReplayRecordingGate")
+struct SessionReplayRecordingGateTests {
+
+    @Test("A launch with no cached failure records from the start")
+    func cleanLaunchRecordsImmediately() {
+        var gate = SessionReplayRecordingGate(hasCachedFailure: false)
+
+        #expect(gate.isScreenCaptureAllowed)
+        #expect(gate.canStartRecording)
+        #expect(gate.isAwaitingVerdict == false)
+
+        // The session was accepted, which is what the gate already assumed.
+        #expect(gate.apply(.allowed) == SessionReplayRecordingGate.Outcome.none)
+        #expect(gate.isScreenCaptureAllowed)
+    }
+
+    @Test("A cached failure withholds screenshots until the backend accepts the session")
+    func cachedFailureWithholdsUntilAccepted() {
+        var gate = SessionReplayRecordingGate(hasCachedFailure: true)
+
+        #expect(gate.isScreenCaptureAllowed == false)
+        #expect(gate.canStartRecording)
+        #expect(gate.isAwaitingVerdict)
+
+        #expect(gate.apply(.allowed) == .releaseScreenCapture)
+        #expect(gate.isScreenCaptureAllowed)
+        #expect(gate.isAwaitingVerdict == false)
+
+        // Later sessions initialize too; the failure is already cleared, so there is nothing to do.
+        #expect(gate.apply(.allowed) == SessionReplayRecordingGate.Outcome.none)
+    }
+
+    @Test("A refusal ends recording for the launch")
+    func refusalEndsRecording() {
+        var gate = SessionReplayRecordingGate(hasCachedFailure: false)
+
+        #expect(gate.apply(.unrecoverable(reason: "blocked")) == .stopRecording(reason: "blocked"))
+        #expect(gate.isScreenCaptureAllowed == false)
+        #expect(gate.canStartRecording == false)
+        // Nothing is owed anymore: the exporter stops talking to the backend until the next launch.
+        #expect(gate.isAwaitingVerdict == false)
+
+        #expect(gate.apply(.unrecoverable(reason: "blocked again")) == SessionReplayRecordingGate.Outcome.none)
+    }
+
+    @Test("A refusal after a recovery still ends recording")
+    func refusalAfterRecovery() {
+        var gate = SessionReplayRecordingGate(hasCachedFailure: true)
+        #expect(gate.apply(.allowed) == .releaseScreenCapture)
+
+        #expect(gate.apply(.unrecoverable(reason: "blocked")) == .stopRecording(reason: "blocked"))
+        #expect(gate.isScreenCaptureAllowed == false)
+        #expect(gate.canStartRecording == false)
+    }
+
+    @Test("An acceptance after a refusal cannot resume recording")
+    func acceptanceAfterRefusalIsIgnored() {
+        var gate = SessionReplayRecordingGate(hasCachedFailure: true)
+        #expect(gate.apply(.unrecoverable(reason: "blocked")) == .stopRecording(reason: "blocked"))
+
+        #expect(gate.apply(.allowed) == SessionReplayRecordingGate.Outcome.none)
+        #expect(gate.isScreenCaptureAllowed == false)
+        #expect(gate.canStartRecording == false)
+    }
+}

--- a/Tests/SessionReplayTests/SessionReplaySamplingTests.swift
+++ b/Tests/SessionReplayTests/SessionReplaySamplingTests.swift
@@ -25,6 +25,7 @@ struct SessionReplaySamplingTests {
         #expect(SessionReplayStartResult.alreadyStarted.isRunning)
         #expect(SessionReplayStartResult.sampledOut.isRunning == false)
         #expect(SessionReplayStartResult.unavailable.isRunning == false)
+        #expect(SessionReplayStartResult.unrecoverableError.isRunning == false)
     }
 
     @Test("sampling decision is not re-evaluated after sampled out")


### PR DESCRIPTION
## Summary

Session Replay kept taking screenshots and retrying even when the backend had refused the session permanently, so recording could not be turned off early in a launch.

- Classify request failures once in `ErrorRecoverability` (in `Common`, outside Session Replay, so any caller of the public graph can reuse it): 4xx is unrecoverable except 400, 408 and 429; timeouts, connectivity loss and malformed responses stay recoverable; GraphQL `errors` are treated as a 4xx unless `extensions.retryable` says otherwise, and an explicit `retryable` in a rejected response body overrides the status code. Unknown errors default to recoverable, so a misclassification can never silently disable recording.
- Act on the verdict in Session Replay: an unrecoverable failure of any of its requests (`initializeSession`, `identifySession`, `pushPayload`) stops screenshots immediately and drains the queue instead of retrying, while recoverable ones keep the existing buffer-and-retry behaviour (events stay in `EventQueue` until it overflows, `BatchWorker` backs off).
- Cache the refusal on disk (`SessionReplayInitializationStore`, keyed by a SHA-256 fingerprint of the SDK key so environments don't gate each other and the key itself is never written). The next launch records everything but screenshots until the backend accepts the session, then clears the cache.
- Probe `initializeSession` eagerly at start rather than waiting for the first export batch, and retry on foreground while screenshots are withheld, so a launch that starts in the background (or with `isEnabled: false` and a later `LDReplay.start()`) still gets its verdict promptly.
- `start()` now returns `.unrecoverableError` for a launch the backend has refused, and `isEnabled` reflects that Session Replay is off.

The recording decision lives in `SessionReplayRecordingGate`, a value type in the style of `SessionReplaySamplingSession`, so the orderings that matter are unit-testable.

`GraphQLFaultInjection` is a debug-only, deliberately unwired helper for exercising both paths on a device; its doc comment says how to hook it up temporarily.

## Test plan

- [x] `./test.sh` passes (no new warnings)
- [x] `ErrorRecoverabilityTests` covers the status matrix, timeouts, the GraphQL `retryable` precedence rules and the body-overrides-status case
- [x] `SessionReplayInitializationStoreTests` covers round-tripping, clearing, environment scoping, reason truncation, and that the SDK key never reaches disk
- [x] `SessionReplayRecordingGateTests` covers a clean launch, a withheld launch that recovers, a refusal, a refusal after recovery, and an acceptance arriving after a refusal
- [ ] Manual: wire up `GraphQLFaultInjection` and confirm a launch on an even minute stops screenshots immediately, and the next launch withholds them until the probe succeeds

## Note for reviewers

`SessionReplayStartResult` gained a case, which is source-breaking for consumers that switch over it exhaustively.

Made with [Cursor](https://cursor.com)
