### PR TITLE
feat: fix double-scaled masks and add imageQuality option

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,14 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
 }
 ```
 
+#### Image Quality
+
+Use `SessionReplayOptions.imageQuality` to control JPEG encoding quality. It accepts values from `0.0` (lowest quality and smallest payload) to `1.0` (highest quality and largest payload), defaults to `0.3`, and clamps values outside that range.
+
+```swift
+SessionReplay(options: .init(imageQuality: 0.75))
+```
+
 ### Manual Start
 
 By default, Session Replay attempts to start recording as soon as the SDK is initialized if `isEnabled` is set to `true`. The `sampleRate` option controls whether that attempt actually starts recording. Use a value from `0.0` to `1.0`, where `0.0` never records and `1.0` always records.

--- a/Sources/LaunchDarklySessionReplay/API/SessionReplayOptions.swift
+++ b/Sources/LaunchDarklySessionReplay/API/SessionReplayOptions.swift
@@ -64,6 +64,10 @@ public struct SessionReplayOptions {
     /// Render scale applied when capturing frames. Usually from 1-4, where
     /// `1` = 160 DPI. Higher values capture at greater resolution. Defaults to `1.0`.
     public var scale: CGFloat
+    /// JPEG encoding quality from `0.0` (lowest quality, smallest payload) to `1.0`
+    /// (highest quality, largest payload). Values outside this range are clamped.
+    /// Defaults to `0.3`.
+    public var imageQuality: CGFloat
     public var renderStrategy: RenderStrategy
     public var serviceName: String
     public var privacy = PrivacyOptions()
@@ -76,6 +80,7 @@ public struct SessionReplayOptions {
                 compression: CompressionMethod = .overlayTiles(),
                 frameRate: Double = 1.0,
                 scale: CGFloat = 1.0,
+                imageQuality: CGFloat = 0.3,
                 renderStrategy: RenderStrategy = .drawHierarchy,
                 log: OSLog = OSLog(subsystem: "com.launchdarkly", category: "LaunchDarklySessionReplayPlugin")) {
         self.isEnabled = isEnabled
@@ -85,6 +90,7 @@ public struct SessionReplayOptions {
         self.compression = compression
         self.frameRate = frameRate
         self.scale = scale
+        self.imageQuality = imageQuality
         self.renderStrategy = renderStrategy
         self.log = log
     }

--- a/Sources/LaunchDarklySessionReplay/BenchMark/CompressionBenchmarkRunner.swift
+++ b/Sources/LaunchDarklySessionReplay/BenchMark/CompressionBenchmarkRunner.swift
@@ -10,8 +10,10 @@ public final class CompressionBenchmarkRunner {
 
     public init() {}
 
-    public func run(method: SessionReplayOptions.CompressionMethod, frames: [RawFrame]) async -> Result {
-        let exportDiffManager = ExportDiffManager(compression: method, scale: 1.0)
+    public func run(method: SessionReplayOptions.CompressionMethod,
+                    frames: [RawFrame],
+                    imageQuality: CGFloat = 0.3) async -> Result {
+        let exportDiffManager = ExportDiffManager(compression: method, scale: 1.0, imageQuality: imageQuality)
         let eventGenerator = RRWebEventGenerator(log: OSLog.default, title: "Benchmark", method: method)
         let encoder = JSONEncoder()
         var bytes = 0

--- a/Sources/LaunchDarklySessionReplay/ScreenCapture/CaptureManager.swift
+++ b/Sources/LaunchDarklySessionReplay/ScreenCapture/CaptureManager.swift
@@ -39,12 +39,13 @@ final class CaptureManager: EventSource {
          compression: SessionReplayOptions.CompressionMethod,
          frameRate: Double,
          scale: CGFloat,
+         imageQuality: CGFloat,
          appLifecycleManager: AppLifecycleManaging,
          eventQueue: EventQueue,
          sessionIdProvider: @Sendable @escaping () -> String) {
         self.captureService = captureService
         self.frameInterval = frameRate > 0 ? 1.0 / frameRate : .infinity
-        self.exportDiffManager = ExportDiffManager(compression: compression, scale: scale)
+        self.exportDiffManager = ExportDiffManager(compression: compression, scale: scale, imageQuality: imageQuality)
         self.eventQueue = eventQueue
         self.appLifecycleManager = appLifecycleManager
         self.rawFrameWriter = debugFrameWriter ? (try? RawFrameWriter()) : nil

--- a/Sources/LaunchDarklySessionReplay/ScreenCapture/ExportDiffManager.swift
+++ b/Sources/LaunchDarklySessionReplay/ScreenCapture/ExportDiffManager.swift
@@ -6,13 +6,14 @@ final class ExportDiffManager {
     private let tileDiffManager: TileDiffManager
     private var currentImages = [ExportFrame.RemoveImage]()
     private var currentImagesIndex: [ImageSignature: Int] = [:]
-    private let format = ExportFormat.jpeg(quality: 0.3)
+    private let format: ExportFormat
     private let compression: SessionReplayOptions.CompressionMethod
     private let lock = NSLock()
     private var keyFrameId: Int = 0
     
-    init(compression: SessionReplayOptions.CompressionMethod, scale: CGFloat) {
+    init(compression: SessionReplayOptions.CompressionMethod, scale: CGFloat, imageQuality: CGFloat) {
         self.compression = compression
+        self.format = .jpeg(quality: imageQuality)
         self.tileDiffManager = TileDiffManager(compression: compression, scale: scale)
     }
 

--- a/Sources/LaunchDarklySessionReplay/ScreenCapture/ImageCaptureService.swift
+++ b/Sources/LaunchDarklySessionReplay/ScreenCapture/ImageCaptureService.swift
@@ -65,7 +65,7 @@ public final class ImageCaptureService: ImageCaptureServicing {
         let enclosingBounds = windowCaptureManager.minimalBoundsEnclosingWindows(windows)
         let renderer = windowCaptureManager.makeRenderer(size: enclosingBounds.size, scale: scale)
         
-        let maskOperationsBefore = windows.map { maskCollector.collectViewMasks(in: $0, window: $0, scale: scale)  }
+        let maskOperationsBefore = windows.map { maskCollector.collectViewMasks(in: $0, window: $0)  }
         let image = renderer.image { ctx in
             windowCaptureManager.drawWindows(windows, into: ctx.cgContext, bounds: enclosingBounds, afterScreenUpdates: false, renderStrategy: renderStrategy)
         }
@@ -84,7 +84,7 @@ public final class ImageCaptureService: ImageCaptureServicing {
                 CATransaction.flush()
             }
 
-            let maskOperationsAfter = windows.map { maskCollector.collectViewMasks(in: $0, window: $0, scale: self.scale)  }
+            let maskOperationsAfter = windows.map { maskCollector.collectViewMasks(in: $0, window: $0)  }
             
             Task {
                 guard maskOperationsBefore.count == maskOperationsAfter.count else {

--- a/Sources/LaunchDarklySessionReplay/ScreenCapture/MaskCollector.swift
+++ b/Sources/LaunchDarklySessionReplay/ScreenCapture/MaskCollector.swift
@@ -40,7 +40,7 @@ final class MaskCollector {
         self.policy = MaskingPolicy(privacySettings: privacySettings)
     }
 
-    func collectViewMasks(in rootView: UIView, window: UIWindow, scale: CGFloat) -> (maskOperations: [MaskOperation], offsetRects: [OffsettedArea]) {
+    func collectViewMasks(in rootView: UIView, window: UIWindow) -> (maskOperations: [MaskOperation], offsetRects: [OffsettedArea]) {
         var operations = [MaskOperation]()
         var offsetRects = [OffsettedArea]()
 
@@ -132,7 +132,7 @@ final class MaskCollector {
         func emitViewMask(view: UIView, layer: CALayer, viewType: AnyClass, className: String, effectiveFrame: CGRect, resolvedExplicitMask: Bool?) -> Bool {
             let shouldMask = policy.shouldMask(view, viewType: viewType, className: className, resolvedExplicitMask: resolvedExplicitMask)
 
-            if shouldMask, let mask = MaskGeometry.createMask(rPresentation: rPresentation, layer: layer, scale: scale) {
+            if shouldMask, let mask = MaskGeometry.createMask(rPresentation: rPresentation, layer: layer) {
                 var operation = MaskOperation(mask: mask, effectiveFrame: effectiveFrame)
 #if DEBUG
                 operation.accessibilityIdentifier = view.accessibilityIdentifier
@@ -163,7 +163,7 @@ final class MaskCollector {
         // Returns `true` if a mask was emitted (the caller should stop recursing).
         func emitLayerOnlyMask(layerClassName: String, layer: CALayer, effectiveFrame: CGRect, resolvedExplicitMask: Bool?) -> Bool {
             let shouldMask = resolvedExplicitMask ?? policy.shouldMaskLayer(className: layerClassName)
-            guard shouldMask, let mask = MaskGeometry.createMask(rPresentation: rPresentation, layer: layer, scale: scale) else {
+            guard shouldMask, let mask = MaskGeometry.createMask(rPresentation: rPresentation, layer: layer) else {
                 return false
             }
             operations.append(MaskOperation(mask: mask, effectiveFrame: effectiveFrame))

--- a/Sources/LaunchDarklySessionReplay/ScreenCapture/MaskGeometry.swift
+++ b/Sources/LaunchDarklySessionReplay/ScreenCapture/MaskGeometry.swift
@@ -9,10 +9,12 @@ import UIKit
 /// visit loop.
 enum MaskGeometry {
     /// Builds a `Mask` describing where `layer` lands inside
-    /// `rPresentation` when drawn at the given `scale`. Returns `nil`
-    /// when the layer has zero area or uses a non-affine transform we
-    /// don't yet handle.
-    static func createMask(rPresentation: CALayer, layer: CALayer, scale: CGFloat) -> Mask? {
+    /// `rPresentation`, in points. The capture context already carries
+    /// the render scale in its CTM (`UIGraphicsImageRendererFormat.scale`),
+    /// so masks must stay in point space or they'd be scaled twice.
+    /// Returns `nil` when the layer has zero area or uses a non-affine
+    /// transform we don't yet handle.
+    static func createMask(rPresentation: CALayer, layer: CALayer) -> Mask? {
         let lBounds = layer.bounds
         guard lBounds.width > 0, lBounds.height > 0 else { return nil }
 
@@ -27,7 +29,7 @@ enum MaskGeometry {
                                                     c: (corner3.x - tx) / max(lBounds.height, 0.0001),
                                                     d: (corner3.y - ty) / max(lBounds.height, 0.0001),
                                                     tx: tx,
-                                                    ty: ty).scaledBy(x: scale, y: scale)
+                                                    ty: ty)
             return Mask.affine(rect: lBounds, transform: affineTransform)
         } else {
             // 3D / perspective transform: the projected shape is a general
@@ -36,12 +38,11 @@ enum MaskGeometry {
             // quad. `convert(_:to:)` walks the full layer chain and applies the
             // perspective projection, so a view that is flipping or tilting in
             // 3D is still covered instead of being left unmasked.
-            let scaleTransform = CGAffineTransform(scaleX: scale, y: scale)
             let quad = Quad(
-                p0: layer.convert(CGPoint(x: lBounds.minX, y: lBounds.minY), to: rPresentation).applying(scaleTransform),
-                p1: layer.convert(CGPoint(x: lBounds.maxX, y: lBounds.minY), to: rPresentation).applying(scaleTransform),
-                p2: layer.convert(CGPoint(x: lBounds.maxX, y: lBounds.maxY), to: rPresentation).applying(scaleTransform),
-                p3: layer.convert(CGPoint(x: lBounds.minX, y: lBounds.maxY), to: rPresentation).applying(scaleTransform)
+                p0: layer.convert(CGPoint(x: lBounds.minX, y: lBounds.minY), to: rPresentation),
+                p1: layer.convert(CGPoint(x: lBounds.maxX, y: lBounds.minY), to: rPresentation),
+                p2: layer.convert(CGPoint(x: lBounds.maxX, y: lBounds.maxY), to: rPresentation),
+                p3: layer.convert(CGPoint(x: lBounds.minX, y: lBounds.maxY), to: rPresentation)
             )
             return Mask.quad(quad)
         }

--- a/Sources/LaunchDarklySessionReplay/SessionReplayService.swift
+++ b/Sources/LaunchDarklySessionReplay/SessionReplayService.swift
@@ -130,6 +130,7 @@ final class SessionReplayService: SessionReplayServicing {
                                              compression: sessonReplayOptions.compression,
                                              frameRate: sessonReplayOptions.frameRate,
                                              scale: sessonReplayOptions.scale,
+                                             imageQuality: sessonReplayOptions.imageQuality,
                                              appLifecycleManager: observabilityContext.appLifecycleManager,
                                              eventQueue: transportService.eventQueue,
                                              sessionIdProvider: observabilityContext.sessionManager.sessionIdProvider)

--- a/Tests/SessionReplayTests/ExportDiffManagerImageQualityTests.swift
+++ b/Tests/SessionReplayTests/ExportDiffManagerImageQualityTests.swift
@@ -1,0 +1,59 @@
+import Testing
+@testable import LaunchDarklySessionReplay
+import CoreGraphics
+import Foundation
+#if canImport(UIKit)
+import UIKit
+
+struct ExportDiffManagerImageQualityTests {
+    private let screenSize = CGSize(width: 120, height: 88)
+
+    @Test("frames are exported as JPEG")
+    func framesAreExportedAsJpeg() throws {
+        let manager = ExportDiffManager(compression: .screenImage, scale: 1.0, imageQuality: 0.3)
+        let exportFrame = try #require(manager.exportFrame(from: makeGradientFrame(timestamp: 1.0)))
+
+        #expect(exportFrame.mimeType == "image/jpeg")
+        let data = try #require(exportFrame.addImages.first?.data)
+        // JPEG start-of-image marker.
+        #expect(data.prefix(2) == Data([0xFF, 0xD8]))
+    }
+
+    @Test("the configured image quality drives JPEG encoding")
+    func configuredImageQualityIsUsedForJpegEncoding() throws {
+        let lowQualitySize = try encodedSize(imageQuality: 0.1)
+        let highQualitySize = try encodedSize(imageQuality: 0.9)
+
+        #expect(lowQualitySize < highQualitySize)
+    }
+
+    private func encodedSize(imageQuality: CGFloat) throws -> Int {
+        let manager = ExportDiffManager(compression: .screenImage, scale: 1.0, imageQuality: imageQuality)
+        let exportFrame = try #require(manager.exportFrame(from: makeGradientFrame(timestamp: 1.0)))
+        return try #require(exportFrame.addImages.first?.data.count)
+    }
+
+    /// A frame with enough high-frequency detail that the JPEG quality factor
+    /// makes a measurable difference in the encoded size.
+    private func makeGradientFrame(timestamp: TimeInterval) -> RawFrame {
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1.0
+        format.opaque = true
+        format.preferredRange = .standard
+        let renderer = UIGraphicsImageRenderer(size: screenSize, format: format)
+        let image = renderer.image { context in
+            for x in stride(from: 0, to: screenSize.width, by: 2) {
+                for y in stride(from: 0, to: screenSize.height, by: 2) {
+                    UIColor(hue: (x + y) / (screenSize.width + screenSize.height),
+                            saturation: 1,
+                            brightness: y / screenSize.height,
+                            alpha: 1).setFill()
+                    context.fill(CGRect(x: x, y: y, width: 2, height: 2))
+                }
+            }
+        }
+        return RawFrame(image: image, timestamp: timestamp, orientation: 0, areas: [])
+    }
+}
+
+#endif

--- a/Tests/SessionReplayTests/MaskCollectorGeometryTests.swift
+++ b/Tests/SessionReplayTests/MaskCollectorGeometryTests.swift
@@ -48,7 +48,7 @@ struct MaskCollectorGeometryTests {
 
     private func collect(in window: UIWindow) -> [MaskOperation] {
         let collector = MaskCollector(privacySettings: .init(maskTextInputs: false, maskLabels: true))
-        return collector.collectViewMasks(in: window, window: window, scale: 1).maskOperations
+        return collector.collectViewMasks(in: window, window: window).maskOperations
     }
 
     private func affineTransform(of operation: MaskOperation) throws -> CGAffineTransform {
@@ -100,6 +100,26 @@ struct MaskCollectorGeometryTests {
         let operations = collect(in: hierarchy.window)
         let transform = try affineTransform(of: try #require(operations.first))
         #expect(abs(transform.tx - 170) < 0.01)
+    }
+
+    @Test("the mask covers the view's frame in points, without any render-scale factor")
+    func maskGeometryIsInPointSpace() async throws {
+        let hierarchy = makeHierarchy()
+        await waitForRenderCommit()
+
+        let operations = collect(in: hierarchy.window)
+        let operation = try #require(operations.first)
+        guard case let .affine(rect, transform) = operation.mask else {
+            throw MaskShapeError.notAffine
+        }
+
+        // The capture context already carries the render scale in its CTM, so
+        // the mask must land exactly on the label's point frame.
+        let masked = rect.applying(transform)
+        #expect(abs(masked.minX - hierarchy.label.frame.minX) < 0.01)
+        #expect(abs(masked.minY - hierarchy.label.frame.minY) < 0.01)
+        #expect(abs(masked.width - hierarchy.label.frame.width) < 0.01)
+        #expect(abs(masked.height - hierarchy.label.frame.height) < 0.01)
     }
 
     @Test("a CameraUI layer in the tree forces model geometry instead of crashing")

--- a/Tests/SessionReplayTests/RawFramesRRWebEventGeneratorTests.swift
+++ b/Tests/SessionReplayTests/RawFramesRRWebEventGeneratorTests.swift
@@ -12,7 +12,7 @@ struct RawFramesRRWebEventGeneratorTests {
     @Test("Converts three raw frames into expected colored images")
     func convertsRawFramesIntoExpectedColors() async {
         let method: SessionReplayOptions.CompressionMethod = .overlayTiles(layers: 15, backtracking: false)
-        let exportDiffManager = ExportDiffManager(compression: method, scale: 1.0)
+        let exportDiffManager = ExportDiffManager(compression: method, scale: 1.0, imageQuality: 0.3)
         let eventGenerator = RRWebEventGenerator(
             log: OSLog(subsystem: "test", category: "test"),
             title: "Benchmark",
@@ -55,7 +55,7 @@ struct RawFramesRRWebEventGeneratorTests {
     @Test("Backtracking emits smaller add and remove-only rollback")
     func backtrackingEmitsSmallerAddAndRemoveOnlyRollback() async {
         let method: SessionReplayOptions.CompressionMethod = .overlayTiles(layers: 15, backtracking: true)
-        let exportDiffManager = ExportDiffManager(compression: method, scale: 1.0)
+        let exportDiffManager = ExportDiffManager(compression: method, scale: 1.0, imageQuality: 0.3)
         let eventGenerator = RRWebEventGenerator(
             log: OSLog(subsystem: "test", category: "test"),
             title: "Benchmark",
@@ -109,7 +109,7 @@ struct RawFramesRRWebEventGeneratorTests {
     @Test("Backtracking across top and bottom bars supports two rollbacks")
     func backtrackingAcrossTopAndBottomBarsSupportsTwoRollbacks() async {
         let method: SessionReplayOptions.CompressionMethod = .overlayTiles(layers: 15, backtracking: true)
-        let exportDiffManager = ExportDiffManager(compression: method, scale: 1.0)
+        let exportDiffManager = ExportDiffManager(compression: method, scale: 1.0, imageQuality: 0.3)
         let eventGenerator = RRWebEventGenerator(
             log: OSLog(subsystem: "test", category: "test"),
             title: "Benchmark",
@@ -188,7 +188,7 @@ struct RawFramesRRWebEventGeneratorTests {
     @Test("Keyframe resets backtracking when layer limit is reached")
     func keyframeResetsBacktrackingWhenLayerLimitReached() async {
         let method: SessionReplayOptions.CompressionMethod = .overlayTiles(layers: 3, backtracking: true)
-        let exportDiffManager = ExportDiffManager(compression: method, scale: 1.0)
+        let exportDiffManager = ExportDiffManager(compression: method, scale: 1.0, imageQuality: 0.3)
         let eventGenerator = RRWebEventGenerator(
             log: OSLog(subsystem: "test", category: "test"),
             title: "Benchmark",

--- a/Tests/SessionReplayTests/SessionReplayModifierPropagationTests.swift
+++ b/Tests/SessionReplayTests/SessionReplayModifierPropagationTests.swift
@@ -174,7 +174,7 @@ struct SessionReplayModifierPropagationTests {
         SessionReplayAssociatedObjects.maskUIView(mask, isEnabled: true)
 
         let collector = MaskCollector(privacySettings: .init(maskTextInputs: false, maskLabels: false))
-        let result = collector.collectViewMasks(in: window, window: window, scale: 1)
+        let result = collector.collectViewMasks(in: window, window: window)
 
         // Exactly one mask op covering the label — the cell, content
         // wrapper, and host must remain unmasked even though they sit
@@ -240,7 +240,7 @@ struct SessionReplayModifierPropagationTests {
         window.layoutIfNeeded()
 
         let collector = MaskCollector(privacySettings: .init(maskTextInputs: true))
-        let result = collector.collectViewMasks(in: window, window: window, scale: 1)
+        let result = collector.collectViewMasks(in: window, window: window)
 
         // Without propagation, `maskTextInputs=true` would have masked
         // the text field. The marker's `unmask` area covers the text
@@ -273,7 +273,7 @@ struct SessionReplayModifierPropagationTests {
         SessionReplayAssociatedObjects.maskUIView(mask, isEnabled: false)
 
         let collector = MaskCollector(privacySettings: .init(maskTextInputs: true))
-        let result = collector.collectViewMasks(in: window, window: window, scale: 1)
+        let result = collector.collectViewMasks(in: window, window: window)
 
         // The text field's frame in root coords (24, 191, 354, 34) is
         // inside the marker's area (16, 183, 370, 50), so it inherits
@@ -316,7 +316,7 @@ struct SessionReplayModifierPropagationTests {
         SessionReplayAssociatedObjects.maskUIView(mask, isEnabled: true)
 
         let collector = MaskCollector(privacySettings: .init(maskTextInputs: false, maskLabels: false))
-        let result = collector.collectViewMasks(in: window, window: window, scale: 1)
+        let result = collector.collectViewMasks(in: window, window: window)
 
         // Exactly one mask op covering the label — the cell background
         // (much larger than the marker area) must remain unmasked.
@@ -355,7 +355,7 @@ struct SessionReplayModifierPropagationTests {
         SessionReplayAssociatedObjects.maskUIView(mask, isEnabled: true)
 
         let collector = MaskCollector(privacySettings: .init(maskTextInputs: false, maskLabels: false))
-        let result = collector.collectViewMasks(in: window, window: window, scale: 1)
+        let result = collector.collectViewMasks(in: window, window: window)
 
         #expect(result.maskOperations.count == 1)
         if let op = result.maskOperations.first {
@@ -374,7 +374,7 @@ struct SessionReplayModifierPropagationTests {
         window.layoutIfNeeded()
 
         let collector = MaskCollector(privacySettings: .init(maskTextInputs: false, maskLabels: false))
-        let result = collector.collectViewMasks(in: window, window: window, scale: 1)
+        let result = collector.collectViewMasks(in: window, window: window)
 
         // The marker's `mask` area covers the content sibling, so the
         // label inside it is masked.
@@ -392,7 +392,7 @@ struct SessionReplayModifierPropagationTests {
         window.layoutIfNeeded()
 
         let collector = MaskCollector(privacySettings: .init(maskTextInputs: true))
-        let result = collector.collectViewMasks(in: window, window: window, scale: 1)
+        let result = collector.collectViewMasks(in: window, window: window)
 
         // The marker's `ignore` area covers the text field; visit
         // skips it entirely.
@@ -410,7 +410,7 @@ struct SessionReplayModifierPropagationTests {
         window.layoutIfNeeded()
 
         let collector = MaskCollector(privacySettings: .init(maskTextInputs: true))
-        let result = collector.collectViewMasks(in: window, window: window, scale: 1)
+        let result = collector.collectViewMasks(in: window, window: window)
 
         // Sanity baseline: when no SwiftUI marker is present,
         // `maskTextInputs` still masks the field.

--- a/Tests/SessionReplayTests/SessionReplayOptionsTests.swift
+++ b/Tests/SessionReplayTests/SessionReplayOptionsTests.swift
@@ -18,4 +18,14 @@ struct SessionReplayOptionsTests {
         #expect(options.frameRate == 2.0)
         #expect(options.renderStrategy == .drawLayers)
     }
+
+    @Test("imageQuality defaults to thirty percent")
+    func imageQualityDefaultsToThirtyPercent() {
+        #expect(SessionReplayOptions().imageQuality == 0.3)
+    }
+
+    @Test("imageQuality can be configured")
+    func imageQualityIsConfigurable() {
+        #expect(SessionReplayOptions(imageQuality: 0.75).imageQuality == 0.75)
+    }
 }


### PR DESCRIPTION
## Summary
- Fix masks being scaled twice (scale was applied in MaskGeometry on top of the render context CTM), so masks came out at scale² and drifted off their views for scale != 1.
- Add SessionReplayOptions.imageQuality (0.0–1.0, default 0.3), threaded through CaptureManager into ExportDiffManager to drive JPEG quality. Mirrors Android's ReplayOptions.imageQuality.

## Test plan
- SessionReplayTests suite passes (87 tests), including new mask point-space and imageQuality encoding tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Fixes **privacy masks drifting off views** when `SessionReplayOptions.scale` is not `1`: mask geometry is now built in **point space** only (`MaskGeometry.createMask` no longer applies render `scale`; `MaskCollector` / `ImageCaptureService` no longer pass `scale` into mask collection). That aligns masks with the capture context, which already scales via `UIGraphicsImageRendererFormat.scale`.
> 
> Adds **`SessionReplayOptions.imageQuality`** (default `0.3`, documented as `0.0`–`1.0`) and threads it through **`CaptureManager` → `ExportDiffManager`**, replacing the hard-coded JPEG quality `0.3`. README documents the option; tests cover point-space masks and that higher quality yields larger JPEG payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53a4228c2ab0b50d083bf0a521443d01799ef629. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->