### PR TITLE
ci: skip pods already published to CocoaPods trunk

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -12,14 +12,14 @@ runs:
     - name: Push LaunchDarklyOtel to CocoaPods
       if: ${{ inputs.dry_run == 'false' }}
       shell: bash
-      run: pod trunk push LaunchDarklyOtel.podspec --allow-warnings --synchronous
+      run: ${{ github.action_path }}/publish-pod.sh LaunchDarklyOtel.podspec
 
     - name: Push LaunchDarklyObservability to CocoaPods
       if: ${{ inputs.dry_run == 'false' }}
       shell: bash
-      run: pod trunk push LaunchDarklyObservability.podspec --allow-warnings --synchronous
+      run: ${{ github.action_path }}/publish-pod.sh LaunchDarklyObservability.podspec
 
     - name: Push LaunchDarklySessionReplay to CocoaPods
       if: ${{ inputs.dry_run == 'false' }}
       shell: bash
-      run: pod trunk push LaunchDarklySessionReplay.podspec --allow-warnings --synchronous
+      run: ${{ github.action_path }}/publish-pod.sh LaunchDarklySessionReplay.podspec

--- a/.github/actions/publish/publish-pod.sh
+++ b/.github/actions/publish/publish-pod.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# Pushes a podspec to CocoaPods trunk. Versions that trunk already has are
+# skipped instead of failing, so a release that got partway through the pods
+# can be re-run without hitting "Unable to accept duplicate entry".
+
+set -euo pipefail
+
+podspec="${1:?usage: publish-pod.sh <podspec>}"
+
+spec_json=$(pod ipc spec "$podspec")
+name=$(printf '%s' "$spec_json" | ruby -rjson -e 'print JSON.parse(STDIN.read).fetch("name")')
+version=$(printf '%s' "$spec_json" | ruby -rjson -e 'print JSON.parse(STDIN.read).fetch("version")')
+
+http_code=$(curl --silent --location --output /dev/null --write-out '%{http_code}' \
+  "https://trunk.cocoapods.org/api/v1/pods/${name}/versions/${version}" || true)
+
+case "$http_code" in
+  200)
+    echo "::notice title=Pod already published::${name} ${version} is already on CocoaPods trunk, skipping push."
+    exit 0
+    ;;
+  404) ;;
+  *)
+    echo "::warning title=Trunk check failed::Could not tell whether ${name} ${version} is published (HTTP ${http_code}), pushing anyway."
+    ;;
+esac
+
+echo "Pushing ${name} ${version} to CocoaPods trunk."
+log=$(mktemp)
+set +e
+pod trunk push "$podspec" --allow-warnings --synchronous 2>&1 | tee "$log"
+status=${PIPESTATUS[0]}
+set -e
+
+if [ "$status" -ne 0 ] && grep -q 'Unable to accept duplicate entry' "$log"; then
+  echo "::notice title=Pod already published::trunk rejected ${name} ${version} as a duplicate, treating as published."
+  exit 0
+fi
+
+exit "$status"


### PR DESCRIPTION
## Summary

- Re-running a release that failed partway through the three `pod trunk push` steps currently cannot succeed: trunk rejects the pods it already accepted with `Unable to accept duplicate entry`, and that failure only shows up after the ~14 minute podspec validation. This happened on 0.52.0, where `LaunchDarklyOtel` published and the other two pods never did.
- The three steps in `.github/actions/publish/action.yml` now call a shared `publish-pod.sh`, which reads the pod name and version from the podspec via `pod ipc spec` and asks the trunk API whether that exact version exists. 200 means published, so it logs a notice and skips. 404 means it pushes. Any other response logs a warning and pushes anyway, so a proxy hiccup or trunk outage can never silently skip a real release.
- As a second guard, a push that still fails with `Unable to accept duplicate entry` is treated as success. That covers the window where trunk registers a version but the job dies before finishing, and it makes the retry immune to the API lagging behind trunk.

## Test plan

- [x] Ran `publish-pod.sh` against live trunk for all three podspecs with `pod trunk push` stubbed out, so nothing was published: `LaunchDarklyOtel 0.52.0` is detected as published and skipped, `LaunchDarklyObservability` and `LaunchDarklySessionReplay` at 0.52.0 are correctly detected as missing and proceed to push.
- [x] Exercised the duplicate-rejection path with a stub that prints trunk's error and exits non-zero; the script exits 0.
- [x] `shellcheck` and `bash -n` clean. Script is committed mode 100755 so Actions can execute it.
- [ ] Confirm on the next release (or a `Publish Pods` re-run for 0.52.0) that Otel is skipped and the remaining pods publish.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Release publish steps now route each pod through **`publish-pod.sh`** instead of calling **`pod trunk push`** directly, so a failed multi-pod release can be re-run without duplicate-trunk failures.
> 
> The script reads name/version from the podspec, checks the trunk API for that version (**skip on 200**, push on **404**, push with a warning on other HTTP codes), then pushes. If trunk still returns **Unable to accept duplicate entry**, the step succeeds so API lag or partial publishes don’t block retries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7ffda86c4c5aad5f3c5d62a140d2ee17f26b1ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->