### PR TITLE
fix(deps): bump iOS Client SDK to 11.4.0

### DIFF
--- a/LaunchDarklyObservability.podspec
+++ b/LaunchDarklyObservability.podspec
@@ -43,13 +43,13 @@ Pod::Spec.new do |s|
     ss.dependency "LaunchDarklyObservability/SDKResourceExtension"
     ss.dependency "LaunchDarklyObservability/OpenTelemetry"
     ss.dependency "LaunchDarklyObservability/Misc"
-    ss.dependency 'LaunchDarkly', '~> 11.2'
+    ss.dependency 'LaunchDarkly', '~> 11.4'
   end
 
   # Common sources + LaunchDarkly SDK dependency (used by GraphQLClient's ld_gzip)
   s.subspec "Common" do |ss|
     ss.source_files = "Sources/Common/**/*.{swift,h,m}"
-    ss.dependency 'LaunchDarkly', '~> 11.2'
+    ss.dependency 'LaunchDarkly', '~> 11.4'
   end
 
   # JSONExporters subspec — OTLP/JSON wire-format models and adapters

--- a/LaunchDarklyOtel.podspec
+++ b/LaunchDarklyOtel.podspec
@@ -29,13 +29,13 @@ Pod::Spec.new do |s|
     ss.dependency "LaunchDarklyOtel/JSONExporters"
     ss.dependency "LaunchDarklyOtel/SDKResourceExtension"
     ss.dependency "LaunchDarklyOtel/OpenTelemetry"
-    ss.dependency 'LaunchDarkly', '~> 11.2'
+    ss.dependency 'LaunchDarkly', '~> 11.4'
   end
 
   # Common sources + LaunchDarkly SDK dependency (used by GraphQLClient's ld_gzip)
   s.subspec "Common" do |ss|
     ss.source_files = "Sources/Common/**/*.{swift,h,m}"
-    ss.dependency 'LaunchDarkly', '~> 11.2'
+    ss.dependency 'LaunchDarkly', '~> 11.4'
   end
 
   # JSONExporters subspec — OTLP/JSON wire-format models and adapters

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/open-telemetry/opentelemetry-swift-core.git", exact: "2.3.0"),
-        .package(url: "https://github.com/launchdarkly/ios-client-sdk.git", exact: "11.2.0"),
+        .package(url: "https://github.com/launchdarkly/ios-client-sdk.git", exact: "11.4.0"),
         // Pinned to 2.6.0-beta.3 for iOS 26+ __crash_info parsing (so Swift
         // runtime trap messages like "Fatal error: Index out of range" are
         // captured). SwiftPM ignores pre-releases with `from:`, so pin exactly.


### PR DESCRIPTION
## Summary

- Bumps the SwiftPM pin for `launchdarkly/ios-client-sdk` from `11.2.0` to `11.4.0`.
- Raises the CocoaPods dependency floor in `LaunchDarklyObservability.podspec` and `LaunchDarklyOtel.podspec` from `~> 11.2` to `~> 11.4` so both package managers land on the same SDK minor.

No source changes — 11.4.0 is a drop-in replacement here.

## Test plan

- [x] `swift package resolve` picks up 11.4.0 (`16e3d24`)
- [x] `./test.sh` passes (87 tests across 11 suites)

Made with [Cursor](https://cursor.com)