### PR TITLE
fix: keep masks behind views whose opacity is animating

### DIFF
--- a/Sources/LaunchDarklySessionReplay/ScreenCapture/MaskCollector.swift
+++ b/Sources/LaunchDarklySessionReplay/ScreenCapture/MaskCollector.swift
@@ -40,7 +40,10 @@ final class MaskCollector {
         self.policy = MaskingPolicy(privacySettings: privacySettings)
     }
 
-    func collectViewMasks(in rootView: UIView, window: UIWindow) -> (maskOperations: [MaskOperation], offsetRects: [OffsettedArea]) {
+    func collectViewMasks(
+        in rootView: UIView,
+        window: UIWindow
+    ) -> (maskOperations: [MaskOperation], offsetRects: [OffsettedArea]) {
         var operations = [MaskOperation]()
         var offsetRects = [OffsettedArea]()
 
@@ -129,7 +132,15 @@ final class MaskCollector {
         }
 
         // Returns `true` if a mask was emitted for this view (the caller should stop recursing).
-        func emitViewMask(view: UIView, layer: CALayer, viewType: AnyClass, className: String, effectiveFrame: CGRect, resolvedExplicitMask: Bool?) -> Bool {
+        func emitViewMask(
+            view: UIView,
+            layer: CALayer,
+            viewType: AnyClass,
+            className: String,
+            effectiveFrame: CGRect,
+            cumulativeOpacity: Float,
+            resolvedExplicitMask: Bool?
+        ) -> Bool {
             let shouldMask = policy.shouldMask(view, viewType: viewType, className: className, resolvedExplicitMask: resolvedExplicitMask)
 
             if shouldMask, let mask = MaskGeometry.createMask(rPresentation: rPresentation, layer: layer) {
@@ -148,9 +159,10 @@ final class MaskCollector {
                 }
             }
 
+        
             // An opaque container fully covers any masks we already emitted inside it,
             // so those masks become redundant and can be dropped.
-            if operations.isNotEmpty, !isTransparent(view: view, pLayer: layer) {
+            if operations.isNotEmpty, !isTransparent(view: view, cumulativeOpacity: cumulativeOpacity) {
                 operations.removeAll { effectiveFrame.contains($0.effectiveFrame) }
             }
 
@@ -161,7 +173,12 @@ final class MaskCollector {
         // backing UIView, so the UIView-based path can't see them. Match by layer class name
         // while still honouring an inherited or marker-area explicit state.
         // Returns `true` if a mask was emitted (the caller should stop recursing).
-        func emitLayerOnlyMask(layerClassName: String, layer: CALayer, effectiveFrame: CGRect, resolvedExplicitMask: Bool?) -> Bool {
+        func emitLayerOnlyMask(
+            layerClassName: String,
+            layer: CALayer,
+            effectiveFrame: CGRect,
+            resolvedExplicitMask: Bool?
+        ) -> Bool {
             let shouldMask = resolvedExplicitMask ?? policy.shouldMaskLayer(className: layerClassName)
             guard shouldMask, let mask = MaskGeometry.createMask(rPresentation: rPresentation, layer: layer) else {
                 return false
@@ -170,7 +187,7 @@ final class MaskCollector {
             return true
         }
 
-        func visit(layer: CALayer, layerClassName: String, inheritedExplicitMask: Bool?) {
+        func visit(layer: CALayer, layerClassName: String, inheritedOpacity: Float, inheritedExplicitMask: Bool?) {
             // On iOS 26+, CameraUI private CALayer subclasses (e.g. ModeLoupeLayer) do not
             // implement init(layer:). Guard at the very top — before ANY property access —
             // because even isHidden/opacity access can trigger CA::Layer::presentation_layer()
@@ -179,6 +196,8 @@ final class MaskCollector {
             if policy.shouldSkipLayer(className: layerClassName) { return }
 
             guard !layer.isHidden, layer.opacity >= policy.minimumAlpha else { return }
+
+            let cumulativeOpacity = inheritedOpacity * effectiveOpacity(of: layer)
 
             // Frame in root coords is needed both for marker-area lookup
             // and for `effectiveFrame`/`MaskOperation`. Compute it once.
@@ -218,6 +237,7 @@ final class MaskCollector {
                                 viewType: viewType,
                                 className: viewClassName,
                                 effectiveFrame: effectiveFrame,
+                                cumulativeOpacity: cumulativeOpacity,
                                 resolvedExplicitMask: resolvedExplicitMask) {
                     return
                 }
@@ -257,10 +277,10 @@ final class MaskCollector {
             }
             guard !safeSublayers.isEmpty else { return }
             if safeSublayers.count == 1 {
-                visit(layer: safeSublayers[0].0, layerClassName: safeSublayers[0].1, inheritedExplicitMask: childInheritedMask)
+                visit(layer: safeSublayers[0].0, layerClassName: safeSublayers[0].1, inheritedOpacity: cumulativeOpacity, inheritedExplicitMask: childInheritedMask)
             } else {
                 safeSublayers.sorted { $0.0.zPosition < $1.0.zPosition }
-                    .forEach { visit(layer: $0.0, layerClassName: $0.1, inheritedExplicitMask: childInheritedMask) }
+                    .forEach { visit(layer: $0.0, layerClassName: $0.1, inheritedOpacity: cumulativeOpacity, inheritedExplicitMask: childInheritedMask) }
             }
         }
 
@@ -275,11 +295,12 @@ final class MaskCollector {
             }
         }
         if !safeRootSublayers.isEmpty {
+            let rootOpacity = effectiveOpacity(of: rPresentation)
             if safeRootSublayers.count == 1 {
-                visit(layer: safeRootSublayers[0].0, layerClassName: safeRootSublayers[0].1, inheritedExplicitMask: nil)
+                visit(layer: safeRootSublayers[0].0, layerClassName: safeRootSublayers[0].1, inheritedOpacity: rootOpacity, inheritedExplicitMask: nil)
             } else {
                 safeRootSublayers.sorted { $0.0.zPosition < $1.0.zPosition }
-                    .forEach { visit(layer: $0.0, layerClassName: $0.1, inheritedExplicitMask: nil) }
+                    .forEach { visit(layer: $0.0, layerClassName: $0.1, inheritedOpacity: rootOpacity, inheritedExplicitMask: nil) }
             }
         }
 
@@ -315,10 +336,32 @@ final class MaskCollector {
     }
 
     // this method should be biased into transparency
-    private func isTransparent(view: UIView, pLayer: CALayer) -> Bool {
-        pLayer.opacity < policy.maximumAlpha
+    private func isTransparent(view: UIView, cumulativeOpacity: Float) -> Bool {
+        cumulativeOpacity < policy.maximumAlpha
         || view.backgroundColor == nil
         || (view.backgroundColor?.cgColor.alpha ?? 0) < CGFloat(policy.maximumAlpha)
+    }
+
+    /// The opacity this layer is being composited with, biased toward transparency: a layer whose
+    /// opacity is animating counts as fully transparent for as long as the animation runs.
+    private func effectiveOpacity(of geometryLayer: CALayer) -> Float {
+        isAnimatingOpacity(geometryLayer.model()) ? 0 : geometryLayer.opacity
+    }
+
+    private func isAnimatingOpacity(_ modelLayer: CALayer) -> Bool {
+        guard let keys = modelLayer.animationKeys(), !keys.isEmpty else { return false }
+        guard !keys.contains("opacity") else { return true }
+
+        return keys.contains { key in
+            guard let animation = modelLayer.animation(forKey: key) else { return false }
+            if let property = animation as? CAPropertyAnimation {
+                return property.keyPath == "opacity"
+            }
+            if let group = animation as? CAAnimationGroup {
+                return group.animations?.contains { ($0 as? CAPropertyAnimation)?.keyPath == "opacity" } ?? false
+            }
+            return false
+        }
     }
 
     func rectFromPresentation(_ rPresentation: CALayer, root: CALayer, layer: CALayer) -> CGRect {

--- a/TestApp/Sources/CrossDissolveCover.swift
+++ b/TestApp/Sources/CrossDissolveCover.swift
@@ -1,0 +1,176 @@
+#if os(iOS)
+import SwiftUI
+import UIKit
+
+extension View {
+    /// Presents `content` over the current screen with a cross-dissolve. `sheet` and `fullScreenCover`
+    /// always slide in, so the presentation is bridged to UIKit to fade the cover in and out instead.
+    ///
+    /// - Parameters:
+    ///   - isPresented: Drives the presentation; setting it back to `false` fades the cover out.
+    ///   - opacity: How far the fade goes, from `0` (invisible) to `1` (fully opaque). Values below `1`
+    ///     leave the cover translucent, so the presenting screen stays visible behind it.
+    ///   - duration: Length of the fade, in seconds.
+    func crossDissolveCover<Content: View>(
+        isPresented: Binding<Bool>,
+        opacity: Double = 1,
+        duration: TimeInterval = 0.35,
+        @ViewBuilder content: @escaping () -> Content
+    ) -> some View {
+        background(
+            CrossDissolveCoverPresenter(
+                isPresented: isPresented,
+                opacity: opacity,
+                duration: duration,
+                content: content
+            )
+        )
+    }
+}
+
+private struct CrossDissolveCoverPresenter<Content: View>: UIViewControllerRepresentable {
+    @Binding var isPresented: Bool
+    let opacity: Double
+    let duration: TimeInterval
+    let content: () -> Content
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    func makeUIViewController(context: Context) -> UIViewController {
+        UIViewController()
+    }
+
+    func updateUIViewController(_ presenter: UIViewController, context: Context) {
+        let shouldPresent = isPresented
+        let opacity = min(max(opacity, 0), 1)
+        let duration = duration
+        let content = content
+        // Presenting from inside a SwiftUI update pass is not allowed, so hand it to the next runloop.
+        DispatchQueue.main.async {
+            context.coordinator.update(
+                shouldPresent: shouldPresent,
+                opacity: CGFloat(opacity),
+                duration: duration,
+                from: presenter,
+                content: content
+            )
+        }
+    }
+
+    final class Coordinator {
+        private let transition = FadeTransitioningDelegate()
+        private weak var cover: UIViewController?
+
+        func update(
+            shouldPresent: Bool,
+            opacity: CGFloat,
+            duration: TimeInterval,
+            from presenter: UIViewController,
+            content: () -> Content
+        ) {
+            transition.opacity = opacity
+            transition.duration = duration
+
+            if shouldPresent, cover == nil, presenter.presentedViewController == nil {
+                // The cover paints its own opaque background: `UIHostingController` owns the background
+                // color of its view, so setting that from here is not reliable, and any translucency
+                // should come from `opacity` alone rather than from gaps in the content.
+                let cover = UIHostingController(
+                    rootView: ZStack {
+                        Color(.systemBackground).ignoresSafeArea()
+                        content()
+                    }
+                )
+                // `overFullScreen` leaves the presenter on screen, which is what turns the fade into a
+                // real cross-dissolve rather than a fade up from black.
+                cover.modalPresentationStyle = .overFullScreen
+                cover.transitioningDelegate = transition
+                self.cover = cover
+                presenter.present(cover, animated: true)
+            } else if !shouldPresent, let cover = cover {
+                self.cover = nil
+                cover.presentingViewController?.dismiss(animated: true)
+            }
+        }
+    }
+}
+
+/// UIKit's built-in `.crossDissolve` can leave the cover stranded part-way through the fade when the
+/// render transaction is flushed mid-animation, which session replay's frame capture does. Animating
+/// the alpha here keeps the end state authoritative: it is the model value, and it is re-applied when
+/// the animation completes, so an interrupted fade still settles on the requested opacity.
+private final class FadeTransitioningDelegate: NSObject, UIViewControllerTransitioningDelegate {
+    var opacity: CGFloat = 1
+    var duration: TimeInterval = 0.35
+
+    func animationController(
+        forPresented presented: UIViewController,
+        presenting: UIViewController,
+        source: UIViewController
+    ) -> UIViewControllerAnimatedTransitioning? {
+        FadeAnimator(isPresenting: true, targetAlpha: opacity, duration: duration)
+    }
+
+    func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
+        FadeAnimator(isPresenting: false, targetAlpha: 0, duration: duration)
+    }
+}
+
+private final class FadeAnimator: NSObject, UIViewControllerAnimatedTransitioning {
+    private let isPresenting: Bool
+    private let targetAlpha: CGFloat
+    private let duration: TimeInterval
+
+    init(isPresenting: Bool, targetAlpha: CGFloat, duration: TimeInterval) {
+        self.isPresenting = isPresenting
+        self.targetAlpha = targetAlpha
+        self.duration = duration
+        super.init()
+    }
+
+    func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
+        duration
+    }
+
+    func animateTransition(using context: UIViewControllerContextTransitioning) {
+        if isPresenting {
+            guard let controller = context.viewController(forKey: .to),
+                  let cover = context.view(forKey: .to) else {
+                context.completeTransition(false)
+                return
+            }
+            let finalFrame = context.finalFrame(for: controller)
+            cover.frame = finalFrame.isEmpty ? context.containerView.bounds : finalFrame
+            cover.alpha = 0
+            context.containerView.addSubview(cover)
+
+            animate({ cover.alpha = self.targetAlpha }, then: {
+                cover.alpha = self.targetAlpha
+                context.completeTransition(!context.transitionWasCancelled)
+            })
+        } else {
+            guard let cover = context.view(forKey: .from) else {
+                context.completeTransition(false)
+                return
+            }
+
+            animate({ cover.alpha = self.targetAlpha }, then: {
+                cover.removeFromSuperview()
+                context.completeTransition(!context.transitionWasCancelled)
+            })
+        }
+    }
+
+    private func animate(_ animations: @escaping () -> Void, then completion: @escaping () -> Void) {
+        UIView.animate(
+            withDuration: duration,
+            delay: 0,
+            options: [.curveEaseInOut, .beginFromCurrentState],
+            animations: animations,
+            completion: { _ in completion() }
+        )
+    }
+}
+#endif

--- a/TestApp/Sources/ExampleAppApp.swift
+++ b/TestApp/Sources/ExampleAppApp.swift
@@ -10,6 +10,7 @@ struct ExampleAppApp: App {
             TVMainMenuView()
             #else
             MainMenuView()
+                .floatingSnapshotButton()
             #endif
         }
     }

--- a/TestApp/Sources/Fruits/Shared/FrutaApp.swift
+++ b/TestApp/Sources/Fruits/Shared/FrutaApp.swift
@@ -15,9 +15,7 @@ struct FrutaAppView: View {
     
     var body: some View {
        // WindowGroup {
-            FruitContentView().overlay(alignment: .topTrailing) {
-                SnapshotButton()
-            }
+            FruitContentView()
                 .environmentObject(model)
         //}
        // .commands {

--- a/TestApp/Sources/MainMenuView.swift
+++ b/TestApp/Sources/MainMenuView.swift
@@ -26,6 +26,9 @@ struct MainMenuView: View {
     /// Single source of truth for the presented sheet. `nil` means none — so tracking back to
     /// "Main Menu" on dismissal is just `activeSheet != nil`.
     @State private var activeSheet: MenuSheet?
+    /// The number pad fades in instead of sliding, so it is presented separately from `activeSheet`.
+    @State private var isNumberPadPresented = false
+    @State private var numberPadOpacity: Double = 1
     @State private var isSessionReplayEnabled: Bool = true
     @State private var selectedScenario: CrashScenario = .throwingError
 
@@ -35,7 +38,6 @@ struct MainMenuView: View {
         case .maskingOneFieldUIKit: MaskingElementsSimpleUIKitView()
         case .maskPropagationSwiftUI: NestedMaskingPropagationView()
         case .maskPropagationUIKit: NestedMaskingPropagationUIKitView()
-        case .numberPad: NumberPadView()
         case .storyboard: StoryboardRootView()
         #if os(iOS)
         case .creditCardUIKit: MaskingCreditCardUIKitView()
@@ -83,7 +85,7 @@ struct MainMenuView: View {
         .trackScreenStack(path, root: "Main Menu") { $0 == "fruta" ? nil : $0 }
         // Re-emit "Main Menu" when the presented sheet is dismissed (SwiftUI does not re-run the
         // presenter's `.onAppear` after a sheet closes).
-        .trackScreenReturn("Main Menu", isPresented: activeSheet != nil)
+        .trackScreenReturn("Main Menu", isPresented: activeSheet != nil || isNumberPadPresented)
         #if os(iOS)
         .onChange(of: path) { newValue in
             if !newValue.contains("fruta") {
@@ -93,6 +95,9 @@ struct MainMenuView: View {
                     }
                 }
             }
+        }
+        .crossDissolveCover(isPresented: $isNumberPadPresented, opacity: numberPadOpacity) {
+            NumberPadView(onClose: { isNumberPadPresented = false })
         }
         #endif
         .sheet(item: $activeSheet) { sheet in
@@ -115,8 +120,18 @@ struct MainMenuView: View {
                 activeSheet = .creditCardSwiftUI
             }
             MaskingGridRow(title: "Number Pad", uikitAction: nil) {
-                activeSheet = .numberPad
+                isNumberPadPresented = true
             }
+            HStack(spacing: 12) {
+                Text("Fade to")
+                // Not down to 0: the number pad still swallows touches when invisible, and its close
+                // button would be impossible to find.
+                Slider(value: $numberPadOpacity, in: 0.1...1)
+                    .accessibilityIdentifier("number_pad.opacity_slider")
+                Text(numberPadOpacity, format: .number.precision(.fractionLength(2)))
+                    .monospacedDigit()
+            }
+            .font(.footnote)
             MaskingGridRow(title: "Mask Propagation", uikitAction: {
                 activeSheet = .maskPropagationUIKit
             }) {
@@ -377,7 +392,6 @@ private enum MenuSheet: Identifiable {
     case maskingOneFieldUIKit
     case maskPropagationSwiftUI
     case maskPropagationUIKit
-    case numberPad
     case storyboard
     #if os(iOS)
     case creditCardUIKit

--- a/TestApp/Sources/SessionReplay/Masking/CreditCardSwiftUIView.swift
+++ b/TestApp/Sources/SessionReplay/Masking/CreditCardSwiftUIView.swift
@@ -147,7 +147,6 @@ struct MaskingCreditCardSwiftUIView: View {
                 } label: {
                     Image(systemName: "checkmark")
                 }
-                SnapshotButton()
             }
         }
         .trackScreen("Masking Credit Card (SwiftUI)")

--- a/TestApp/Sources/SessionReplay/Masking/CreditCardViewController.swift
+++ b/TestApp/Sources/SessionReplay/Masking/CreditCardViewController.swift
@@ -702,7 +702,6 @@ struct MaskingCreditCardUIKitView: View {
                     } label: {
                         Image(systemName: "checkmark")
                     }
-                    SnapshotButton()
                 }
         }
     }

--- a/TestApp/Sources/SessionReplay/Masking/MaskingElementsView.swift
+++ b/TestApp/Sources/SessionReplay/Masking/MaskingElementsView.swift
@@ -33,7 +33,6 @@ struct MaskingElementsView: View {
                 } label: {
                     Image(systemName: "checkmark")
                 }
-                SnapshotButton()
             }
         }
         .trackScreen("Masking Elements (UIKit)")

--- a/TestApp/Sources/SessionReplay/Masking/NestedMaskingPropagationUIKitViewController.swift
+++ b/TestApp/Sources/SessionReplay/Masking/NestedMaskingPropagationUIKitViewController.swift
@@ -164,7 +164,6 @@ struct NestedMaskingPropagationUIKitView: View {
                     } label: {
                         Image(systemName: "checkmark")
                     }
-                    SnapshotButton()
                 }
         }
     }

--- a/TestApp/Sources/SessionReplay/Masking/NestedMaskingPropagationView.swift
+++ b/TestApp/Sources/SessionReplay/Masking/NestedMaskingPropagationView.swift
@@ -67,7 +67,6 @@ struct NestedMaskingPropagationView: View {
                 } label: {
                     Image(systemName: "checkmark")
                 }
-                SnapshotButton()
             }
         }
         .trackScreen("Nested Masking Propagation")

--- a/TestApp/Sources/SessionReplay/Masking/SimpleNestedViewController.swift
+++ b/TestApp/Sources/SessionReplay/Masking/SimpleNestedViewController.swift
@@ -115,7 +115,6 @@ struct MaskingElementsSimpleUIKitView: View {
                     } label: {
                         Image(systemName: "checkmark")
                     }
-                    SnapshotButton()
                 }
         }
         .trackScreen("Masking Simple View (UIKit)")

--- a/TestApp/Sources/SessionReplay/NumberPad/NotebookView.swift
+++ b/TestApp/Sources/SessionReplay/NumberPad/NotebookView.swift
@@ -47,7 +47,6 @@ struct NotebookView: View {
                 } label: {
                     Image(systemName: "checkmark")
                 }
-                SnapshotButton()
             }
         }
         .trackScreen("Notebook (SwiftUI)")

--- a/TestApp/Sources/SessionReplay/NumberPad/NumberPadView.swift
+++ b/TestApp/Sources/SessionReplay/NumberPad/NumberPadView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 import LaunchDarklyObservability
 
 struct NumberPadView: View {
+    /// Set when the screen is presented outside of a SwiftUI presentation, where `dismiss` has no effect.
+    var onClose: (() -> Void)?
     @State var text = ""
     @Environment(\.dismiss) var dismiss
     
@@ -28,11 +30,14 @@ struct NumberPadView: View {
             .navigationTitle("Number Pad (SwiftUI)")
             .toolbar {
                 Button {
-                    dismiss()
+                    if let onClose {
+                        onClose()
+                    } else {
+                        dismiss()
+                    }
                 } label: {
                     Image(systemName: "checkmark")
                 }
-                SnapshotButton()
             }
         }
         .trackScreen("Number Pad (SwiftUI)")

--- a/TestApp/Sources/SessionReplay/ScreenshotTester/FloatingSnapshotButton.swift
+++ b/TestApp/Sources/SessionReplay/ScreenshotTester/FloatingSnapshotButton.swift
@@ -1,0 +1,123 @@
+#if os(iOS)
+import SwiftUI
+import UIKit
+
+extension View {
+    /// Installs a single snapshot control in its own passthrough window, so it stays reachable from
+    /// every screen — including sheets and UIKit-presented content — instead of being added per screen.
+    func floatingSnapshotButton() -> some View {
+        modifier(FloatingSnapshotButtonInstaller())
+    }
+}
+
+private struct FloatingSnapshotButtonInstaller: ViewModifier {
+    private let didBecomeActive = NotificationCenter.default
+        .publisher(for: UIApplication.didBecomeActiveNotification)
+
+    func body(content: Content) -> some View {
+        content
+            .onAppear { FloatingSnapshotButtonWindow.install() }
+            .onReceive(didBecomeActive) { _ in FloatingSnapshotButtonWindow.install() }
+    }
+}
+
+private final class FloatingSnapshotButtonWindow: UIWindow {
+    private static var shared: FloatingSnapshotButtonWindow?
+
+    static func install() {
+        guard shared == nil, let scene = foregroundScene else { return }
+
+        let window = FloatingSnapshotButtonWindow(windowScene: scene)
+        // Above the app's own overlay windows (see `WindowSheetPresenter`) so the control is never
+        // covered by the screens it is used to capture.
+        window.windowLevel = .alert + 10
+        window.backgroundColor = .clear
+        window.rootViewController = FloatingSnapshotButtonController()
+        window.isHidden = false
+        shared = window
+    }
+
+    private static var foregroundScene: UIWindowScene? {
+        let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
+        return scenes.first { $0.activationState == .foregroundActive } ?? scenes.first
+    }
+
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        let hit = super.hitTest(point, with: event)
+        // A hit on the bare window means the touch missed the button, so let the app's windows have it.
+        return hit === self ? nil : hit
+    }
+}
+
+private final class FloatingSnapshotButtonController: UIViewController {
+    private static let buttonSize = CGSize(width: 56, height: 56)
+    private static let margin: CGFloat = 16
+
+    private let button = UIHostingController(rootView: SnapshotButton())
+    private var buttonCenter: CGPoint?
+
+    override func loadView() {
+        view = PassthroughView()
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .clear
+
+        addChild(button)
+        button.view.backgroundColor = .clear
+        view.addSubview(button.view)
+        button.didMove(toParent: self)
+
+        button.view.addGestureRecognizer(
+            UIPanGestureRecognizer(target: self, action: #selector(handlePan))
+        )
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        let center = clamped(buttonCenter ?? defaultCenter)
+        buttonCenter = center
+        button.view.frame = CGRect(origin: .zero, size: Self.buttonSize)
+        button.view.center = center
+    }
+
+    @objc private func handlePan(_ gesture: UIPanGestureRecognizer) {
+        let translation = gesture.translation(in: view)
+        gesture.setTranslation(.zero, in: view)
+        let center = clamped(
+            CGPoint(x: button.view.center.x + translation.x, y: button.view.center.y + translation.y)
+        )
+        buttonCenter = center
+        button.view.center = center
+    }
+
+    private var defaultCenter: CGPoint {
+        let insets = view.safeAreaInsets
+        return CGPoint(
+            x: view.bounds.maxX - insets.right - Self.margin - Self.buttonSize.width / 2,
+            y: view.bounds.maxY - insets.bottom - Self.margin - Self.buttonSize.height / 2
+        )
+    }
+
+    private func clamped(_ center: CGPoint) -> CGPoint {
+        let insets = view.safeAreaInsets
+        let halfWidth = Self.buttonSize.width / 2
+        let halfHeight = Self.buttonSize.height / 2
+        let minX = view.bounds.minX + insets.left + halfWidth
+        let maxX = view.bounds.maxX - insets.right - halfWidth
+        let minY = view.bounds.minY + insets.top + halfHeight
+        let maxY = view.bounds.maxY - insets.bottom - halfHeight
+        return CGPoint(
+            x: min(max(center.x, minX), max(minX, maxX)),
+            y: min(max(center.y, minY), max(minY, maxY))
+        )
+    }
+}
+
+private final class PassthroughView: UIView {
+    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+        subviews.contains { !$0.isHidden && $0.alpha > 0 && $0.frame.contains(point) }
+    }
+}
+#endif

--- a/TestApp/Sources/SessionReplay/ScreenshotTester/SnapshotButton.swift
+++ b/TestApp/Sources/SessionReplay/ScreenshotTester/SnapshotButton.swift
@@ -1,17 +1,23 @@
 import SwiftUI
 
 struct SnapshotButton: View {
-    @StateObject var viewModel = MaskingElementsViewModel()
+    @StateObject private var viewModel = MaskingElementsViewModel()
 
     var body: some View {
         Button {
             viewModel.captureShapShot()
         } label: {
             Image(systemName: "camera")
-        }.sheet(isPresented: $viewModel.isImagePresented) {
-            print(viewModel.isImagePresented)
-            let image = viewModel.capturedImage ?? UIImage()
-            return CapturedImageView(image: image)
+                .font(.system(size: 22, weight: .semibold))
+                .foregroundColor(.white)
+                .frame(width: 56, height: 56)
+                .background(Circle().fill(Color.accentColor))
+                .shadow(color: .black.opacity(0.3), radius: 6, y: 3)
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("a-snapshot")
+        .sheet(isPresented: $viewModel.isImagePresented) {
+            CapturedImageView(image: viewModel.capturedImage ?? UIImage())
         }
     }
 }

--- a/Tests/SessionReplayTests/MaskCollectorAbsorptionTests.swift
+++ b/Tests/SessionReplayTests/MaskCollectorAbsorptionTests.swift
@@ -1,0 +1,114 @@
+import Testing
+@testable import LaunchDarklySessionReplay
+import UIKit
+
+/// An opaque view covering the screen absorbs the masks it hides, because nothing behind it is
+/// visible in the captured frame. These tests pin down when that absorption must *not* happen: while
+/// a screen is fading in, or while it stays translucent, the content behind it is still on display
+/// and its masks have to survive.
+@MainActor
+struct MaskCollectorAbsorptionTests {
+    private struct Hierarchy {
+        let window: UIWindow
+        let label: UILabel
+        let cover: UIView
+    }
+
+    /// A masked label with an opaque, screen-filling view over it — the shape of a modal presented
+    /// over a screen that has something to hide.
+    private func makeHierarchy(coverNestedIn wrapper: UIView? = nil) -> Hierarchy {
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 300, height: 300))
+        let label = UILabel(frame: CGRect(x: 50, y: 100, width: 100, height: 20))
+        label.text = "secret"
+        window.addSubview(label)
+
+        let cover = UIView(frame: window.bounds)
+        cover.backgroundColor = .white
+        if let wrapper {
+            wrapper.frame = window.bounds
+            window.addSubview(wrapper)
+            wrapper.addSubview(cover)
+        } else {
+            window.addSubview(cover)
+        }
+
+        window.makeKeyAndVisible()
+        window.layoutIfNeeded()
+        return Hierarchy(window: window, label: label, cover: cover)
+    }
+
+    /// Runs an opacity animation that holds the same value from start to finish, so neither the model
+    /// layer nor the presentation layer reports anything but a fully opaque cover. Only the presence
+    /// of the animation says the cover is still being blended over the screen behind it — which is the
+    /// state a capture lands in before Core Animation has committed the fade's interpolated values.
+    private func addHeldOpacityAnimation(to layer: CALayer) {
+        let fade = CABasicAnimation(keyPath: "opacity")
+        fade.fromValue = 1
+        fade.toValue = 1
+        fade.duration = 60
+        layer.add(fade, forKey: "opacity")
+    }
+
+    private func waitForRenderCommit() async {
+        CATransaction.flush()
+        try? await Task.sleep(nanoseconds: 200_000_000)
+        CATransaction.flush()
+    }
+
+    private func collect(in window: UIWindow) -> [MaskOperation] {
+        let collector = MaskCollector(privacySettings: .init(maskTextInputs: false, maskLabels: true))
+        return collector.collectViewMasks(in: window, window: window).maskOperations
+    }
+
+    @Test("an opaque cover absorbs the masks it hides")
+    func opaqueCoverAbsorbsMasks() async throws {
+        let hierarchy = makeHierarchy()
+        await waitForRenderCommit()
+
+        #expect(collect(in: hierarchy.window).isEmpty)
+    }
+
+    @Test("a cover whose opacity is animating keeps the masks behind it")
+    func fadingCoverKeepsMasks() async throws {
+        let hierarchy = makeHierarchy()
+        addHeldOpacityAnimation(to: hierarchy.cover.layer)
+        await waitForRenderCommit()
+
+        // Precondition: nothing but the running animation hints at the fade.
+        #expect(hierarchy.cover.layer.opacity == 1)
+        #expect(hierarchy.cover.layer.presentation()?.opacity ?? 1 == 1)
+
+        #expect(collect(in: hierarchy.window).count == 1)
+    }
+
+    @Test("a cover keeps the masks behind it while an ancestor's opacity is animating")
+    func fadingAncestorKeepsMasks() async throws {
+        // UIKit fades a container view rather than the screen itself for presentations and pushes, so
+        // the opaque view is nested one level down from the animation.
+        let container = UIView()
+        let hierarchy = makeHierarchy(coverNestedIn: container)
+        addHeldOpacityAnimation(to: container.layer)
+        await waitForRenderCommit()
+
+        #expect(collect(in: hierarchy.window).count == 1)
+    }
+
+    @Test("a translucent cover keeps the masks behind it")
+    func translucentCoverKeepsMasks() async throws {
+        let hierarchy = makeHierarchy()
+        hierarchy.cover.alpha = 0.5
+        await waitForRenderCommit()
+
+        #expect(collect(in: hierarchy.window).count == 1)
+    }
+
+    @Test("a cover keeps the masks behind it while a translucent ancestor is on screen")
+    func translucentAncestorKeepsMasks() async throws {
+        let container = UIView()
+        let hierarchy = makeHierarchy(coverNestedIn: container)
+        container.alpha = 0.5
+        await waitForRenderCommit()
+
+        #expect(collect(in: hierarchy.window).count == 1)
+    }
+}


### PR DESCRIPTION
## Summary

- **Session replay fix:** a screen fading in absorbed the masks of everything behind it, so masked content was captured in the clear for the length of the transition. The redundant-mask pass judged opacity from a single view's own layer, but `UIView.animate` writes the animation's final value to the model layer immediately and the presentation copy only carries interpolated values once Core Animation has committed the animation — so an incoming cover reads as fully opaque while the screen behind it is still on display. Nesting hid it further: an opaque view inside a container UIKit is fading looked solid. Opacity is now accumulated down the layer tree, and a layer with a live opacity animation counts as fully transparent while it runs. Only absorption consumes the value, so a view that is fading in still contributes its own masks.
- **Test app:** the snapshot control moved out of eight screens' toolbars into a single draggable passthrough window above the app, and the number pad is now presented with a UIKit cross-dissolve whose end opacity is adjustable from the main menu — which is the scenario that surfaced the bug above.

## Test plan

- [x] `MaskCollectorAbsorptionTests` — five cases: an opaque cover still absorbs the masks it hides; masks survive under a fading cover, a fading ancestor, a translucent cover and a translucent ancestor. The fade cases hold the animation at opacity 1 so neither the model nor the presentation layer reveals the fade, reproducing the race rather than relying on catching a mid-interpolation value.
- [x] Verified the three new fade/ancestor tests fail without the fix and pass with it.
- [x] Full `SessionReplayTests` suite passes on the iOS simulator.
- [x] Test app builds for iOS. (The tvOS build fails on pre-existing `SpatialTapGesture` errors in `View+ldClick.swift`, unrelated to these changes.)
- [ ] Manually confirm the number pad fade and the floating button placement on device.

## Notes

- Absorption is suppressed while any ancestor is mid-fade, so a few frames retain more masks than before. Benchmarking a 610-view / 500-mask hierarchy over 200 passes showed the added per-layer probe sits below run-to-run noise (2.2–3.0 ms per pass with the change, 2.5 ms without).
- The floating snapshot button is iOS-only; a focus-driven overlay window does not behave well on tvOS, so that platform no longer shows the control.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Fixes a session replay privacy bug where **opaque covers absorbed masks** for content still visible during cross-dissolve transitions. `MaskCollector` now **accumulates opacity down the layer tree** and treats layers with a **live opacity animation** as transparent for the redundant-mask pass, so labels behind a fading modal stay masked until the cover is truly opaque.
> 
> Adds **`MaskCollectorAbsorptionTests`** (opaque absorb, fading cover/ancestor, translucent cover/ancestor).
> 
> **Test app:** one **draggable floating snapshot button** (passthrough window at app root) replaces per-screen toolbar buttons; the number pad uses a new **`crossDissolveCover`** UIKit fade with an adjustable target opacity slider on the main menu.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f91fc1dc39eecfbfbe075823bbaaa1aebd33c402. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->